### PR TITLE
Feat: S3를 통한 영상 저장 및 딥페이크 탐지 기본 구조 구현

### DIFF
--- a/deeptruth/build.gradle
+++ b/deeptruth/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/s3/S3FileDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/s3/S3FileDTO.java
@@ -1,0 +1,18 @@
+package com.deeptruth.deeptruth.base.dto.s3;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class S3FileDTO {
+    private String originalFileName;
+    private String uploadFileName;
+    private String uploadFilePath;
+    private String uploadFileUrl;
+    private String uploadFileFormat;
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/S3Config.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.deeptruth.deeptruth.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${spring.s3.access-key}")
+    private String accessKey;
+
+    @Value("${spring.s3.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionController.java
@@ -6,6 +6,7 @@ import com.deeptruth.deeptruth.service.DeepfakeDetectionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -15,6 +16,15 @@ import java.util.List;
 public class DeepfakeDetectionController {
 
     private final DeepfakeDetectionService deepfakeDetectionService;
+
+    @PostMapping
+    public ResponseEntity<ResponseDTO> uploadVideo(Long userId, @RequestPart("file")MultipartFile multipartFile){
+        DeepfakeDetectionDTO result = deepfakeDetectionService.uploadVideo(userId, multipartFile);
+
+        return ResponseEntity.ok(
+                ResponseDTO.success(200, "딥페이크 탐지 영상 업로드 성공", result)
+        );
+    }
 
     @GetMapping
     public ResponseEntity<ResponseDTO> getAllDetections(@RequestParam Long userId){

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/AmazonS3Service.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/AmazonS3Service.java
@@ -1,0 +1,57 @@
+package com.deeptruth.deeptruth.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.deeptruth.deeptruth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AmazonS3Service {
+
+    @Value("${spring.s3.bucket}")
+    private String bucketName;
+
+    private final AmazonS3Client amazonS3Client;
+
+    private final UserRepository userRepository;
+
+    public String uploadFile(String folder, MultipartFile multipartFile) {
+        String uploadFileUrl = "";
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(multipartFile.getSize());
+        objectMetadata.setContentType(multipartFile.getContentType());
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+
+            String keyName = folder + "/" + UUID.randomUUID() + "." + multipartFile.getOriginalFilename();
+
+            // S3에 폴더 및 파일 업로드
+            amazonS3Client.putObject(
+                    new PutObjectRequest(bucketName, keyName, inputStream, objectMetadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead));
+
+            // S3에 업로드한 폴더 및 파일 URL
+            uploadFileUrl = amazonS3Client.getUrl(bucketName, keyName).toString();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+            log.error("Filed upload failed", e);
+        }
+
+        return uploadFileUrl;
+    }
+
+}

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionControllerTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionControllerTest.java
@@ -36,11 +36,19 @@ public class DeepfakeDetectionControllerTest {
     void uploadVideo_ShouldReturn200AndResponseDTO() throws Exception {
         // given
         Long userId = 1L;
+        Float deepfakeResult = 0.7F;
+        Float riskScore = 0.7F;
         MockMultipartFile file = new MockMultipartFile("file", "video.mp4", "video/mp4", "fake video content".getBytes());
-        String expectedUrl = "https://s3.amazonaws.com/deepfake/video.mp4";
+
+        DeepfakeDetectionDTO mockDto = DeepfakeDetectionDTO.builder()
+                .filePath("https://s3.amazonaws.com/deepfake/video.mp4")
+                .deepfakeResult(deepfakeResult)
+                .riskScore(riskScore)
+                .build();
 
         given(deepfakeDetectionService.uploadVideo(eq(userId), any(MultipartFile.class)))
-                .willReturn(expectedUrl);
+                .willReturn(mockDto);
+
 
         // when & then
         mockMvc.perform(multipart("/deepfake")
@@ -50,7 +58,9 @@ public class DeepfakeDetectionControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.message").value("딥페이크 탐지 영상 업로드 성공"))
-                .andExpect(jsonPath("$.data").value(expectedUrl));
+                .andExpect(jsonPath("$.data.filePath").value("https://s3.amazonaws.com/deepfake/video.mp4"))
+                .andExpect(jsonPath("$.data.deepfakeResult").value(deepfakeResult))
+                .andExpect(jsonPath("$.data.riskScore").value(riskScore));
     }
 
     @Test

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/service/DeepfakeDetectionServiceTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/service/DeepfakeDetectionServiceTest.java
@@ -12,13 +12,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import static org.mockito.BDDMockito.then;
 
+
+import java.io.IOException;
 import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 class DeepfakeDetectionServiceTest {
@@ -31,6 +35,9 @@ class DeepfakeDetectionServiceTest {
 
     @Mock
     private DeepfakeDetectionRepository deepfakeDetectionRepository;
+
+    @Mock
+    private AmazonS3Service amazonS3Service;
 
     private User mockUser;
     private DeepfakeDetection detection1;
@@ -66,24 +73,25 @@ class DeepfakeDetectionServiceTest {
                 .build();
     }
 
-
     @Test
-    @DisplayName("전체 탐지 결과를 반환한다")
-    void getAllResult() {
+    @DisplayName("영상을 업로드한다")
+    void uploadVideo_ShouldReturnS3Url() throws IOException {
         // given
-        when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
-        when(deepfakeDetectionRepository.findAllByUser(mockUser)).thenReturn(List.of(detection1, detection2));
+        Long userId = 1L;
+        MultipartFile multipartFile = new MockMultipartFile("file", "video.mp4", "video/mp4", "video content".getBytes());
+        User mockUser = User.builder().userId(userId).name("tester").build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+        given(amazonS3Service.uploadFile(anyString(), any(MultipartFile.class)))
+                .willReturn("https://s3.amazonaws.com/deepfake/video.mp4");
 
         // when
-        List<DeepfakeDetectionDTO> result = deepfakeDetectionService.getAllResult(1L);
+        String result = deepfakeDetectionService.uploadVideo(userId, multipartFile);
 
         // then
-        assertEquals(2, result.size());
-        assertEquals("path1.mp4", result.get(0).getFilePath());
-        assertEquals("path2.mp4", result.get(1).getFilePath());
-
-        // repository 호출 여부 검증 (옵션)
-        verify(deepfakeDetectionRepository, times(1)).findAllByUser(mockUser);
+        assertEquals("https://s3.amazonaws.com/deepfake/video.mp4", result);
+        then(userRepository).should().findById(userId);
+        then(amazonS3Service).should().uploadFile("deepfake", multipartFile);
     }
 
     @Test


### PR DESCRIPTION
## 📝 Summary
- AWS S3와 연결하여 이미지, 영상 업로드 구현
- 딥페이크 탐지 기본 구조 구현
- 사용자가 영상 업로드 시 s3에 영상 저장, 탐지결과 DeepfakeDetectionDTO 반환

## 💻 Describe your changes
- 아직 flask 서버와 연결되지 않아 하드코딩으로 구현해두었습니다.
- 추후 flask 서버와 연결하여 실제 반환값을 return할 예정입니다 

## #️⃣ Issue number and link
> #37 

## 💬 Message to the Reviewer
- DeepfakeDetection Entity에서 real, fake 여부를 받은 필드가 필요할 것 같습니다. 추가로 flask 서버에서 의심되는 특정 영역을 반환하는 json의 detectedPart 필드 구현이 불가능할 것 같아 없애야할 것 같습니다. 
