### PR TITLE
Refactor: DeepfakeDetection Entity 필드 수정 및 DTO, Test 수정

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/Enum/DeepfakeResult.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/Enum/DeepfakeResult.java
@@ -1,0 +1,5 @@
+package com.deeptruth.deeptruth.base.Enum;
+
+public enum DeepfakeResult {
+    REAL, FAKE
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/DeepfakeDetectionDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/DeepfakeDetectionDTO.java
@@ -1,5 +1,6 @@
 package com.deeptruth.deeptruth.base.dto.deepfake;
 
+import com.deeptruth.deeptruth.base.Enum.DeepfakeResult;
 import com.deeptruth.deeptruth.entity.DeepfakeDetection;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,18 +12,16 @@ import java.time.LocalDateTime;
 public class DeepfakeDetectionDTO {
     private Long id;
     private String filePath;
-    private Float deepfakeResult;
+    private DeepfakeResult result;
     private Float riskScore;
-    private String detectedPart;
     private LocalDateTime createdAt;
 
     public static DeepfakeDetectionDTO fromEntity(DeepfakeDetection entity) {
         return DeepfakeDetectionDTO.builder()
                 .id(entity.getDeepfakeDetectionId())
                 .filePath(entity.getFilePath())
-                .deepfakeResult(entity.getDeepfakeResult())
+                .result(entity.getResult())
                 .riskScore(entity.getRiskScore())
-                .detectedPart(entity.getDetectedPart())
                 .createdAt(entity.getCreatedAt())
                 .build();
     }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/DeepfakeDetection.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/DeepfakeDetection.java
@@ -1,5 +1,6 @@
 package com.deeptruth.deeptruth.entity;
 
+import com.deeptruth.deeptruth.base.Enum.DeepfakeResult;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -24,14 +25,12 @@ public class DeepfakeDetection {
     @Column(nullable=false, length = 255)
     private String filePath;
 
-    @Column
-    private Float deepfakeResult;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DeepfakeResult result;
 
     @Column
     private Float riskScore;
-
-    @Column(columnDefinition = "JSON")
-    private String detectedPart;
 
     @Column(nullable=false, updatable = false)
     private LocalDateTime createdAt;

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
@@ -1,5 +1,6 @@
 package com.deeptruth.deeptruth.service;
 
+import com.deeptruth.deeptruth.base.Enum.DeepfakeResult;
 import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionDTO;
 import com.deeptruth.deeptruth.entity.DeepfakeDetection;
 import com.deeptruth.deeptruth.entity.User;
@@ -30,14 +31,14 @@ public class DeepfakeDetectionService {
         User user = userRepository.findById(userId).orElseThrow();
         String filePath = amazonS3Service.uploadFile("deepfake", multipartFile);
 
-        Float deepfakeResult = 0.7F;
+        DeepfakeResult deepfakeResult = DeepfakeResult.FAKE;
         Float riskScore = 0.7F;
 
 
         DeepfakeDetection detection = DeepfakeDetection.builder()
                 .user(user)
                 .filePath(filePath)
-                .deepfakeResult(deepfakeResult)
+                .result(deepfakeResult)
                 .riskScore(riskScore)
                 .build();
 

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionControllerTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionControllerTest.java
@@ -1,7 +1,9 @@
 package com.deeptruth.deeptruth.controller;
 
+import com.deeptruth.deeptruth.base.Enum.DeepfakeResult;
 import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionDTO;
 import com.deeptruth.deeptruth.service.DeepfakeDetectionService;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -36,13 +38,13 @@ public class DeepfakeDetectionControllerTest {
     void uploadVideo_ShouldReturn200AndResponseDTO() throws Exception {
         // given
         Long userId = 1L;
-        Float deepfakeResult = 0.7F;
+        DeepfakeResult deepfakeResult = DeepfakeResult.FAKE;
         Float riskScore = 0.7F;
         MockMultipartFile file = new MockMultipartFile("file", "video.mp4", "video/mp4", "fake video content".getBytes());
 
         DeepfakeDetectionDTO mockDto = DeepfakeDetectionDTO.builder()
                 .filePath("https://s3.amazonaws.com/deepfake/video.mp4")
-                .deepfakeResult(deepfakeResult)
+                .result(deepfakeResult)
                 .riskScore(riskScore)
                 .build();
 
@@ -59,7 +61,7 @@ public class DeepfakeDetectionControllerTest {
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.message").value("딥페이크 탐지 영상 업로드 성공"))
                 .andExpect(jsonPath("$.data.filePath").value("https://s3.amazonaws.com/deepfake/video.mp4"))
-                .andExpect(jsonPath("$.data.deepfakeResult").value(deepfakeResult))
+                .andExpect(jsonPath("$.data.result").value(Matchers.containsString("FAKE")))
                 .andExpect(jsonPath("$.data.riskScore").value(riskScore));
     }
 
@@ -71,9 +73,8 @@ public class DeepfakeDetectionControllerTest {
         DeepfakeDetectionDTO dto = DeepfakeDetectionDTO.builder()
                 .id(1L)
                 .filePath("test/path.mp4")
-                .deepfakeResult(0.85f)
+                .result(DeepfakeResult.FAKE)
                 .riskScore(0.75f)
-                .detectedPart("{\"face\": true}")
                 .createdAt(LocalDateTime.now())
                 .build();
 
@@ -99,9 +100,8 @@ public class DeepfakeDetectionControllerTest {
         DeepfakeDetectionDTO dto = DeepfakeDetectionDTO.builder()
                 .id(id)
                 .filePath("test/path.mp4")
-                .deepfakeResult(0.85f)
+                .result(DeepfakeResult.FAKE)
                 .riskScore(0.75f)
-                .detectedPart("{\"face\": true}")
                 .createdAt(LocalDateTime.now())
                 .build();
 

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/service/DeepfakeDetectionServiceTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/service/DeepfakeDetectionServiceTest.java
@@ -1,5 +1,6 @@
 package com.deeptruth.deeptruth.service;
 
+import com.deeptruth.deeptruth.base.Enum.DeepfakeResult;
 import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionDTO;
 import com.deeptruth.deeptruth.entity.DeepfakeDetection;
 import com.deeptruth.deeptruth.entity.User;
@@ -56,9 +57,8 @@ class DeepfakeDetectionServiceTest {
                 .deepfakeDetectionId(1L)
                 .user(mockUser)
                 .filePath("path1.mp4")
-                .deepfakeResult(0.9f)
+                .result(DeepfakeResult.FAKE)
                 .riskScore(0.8f)
-                .detectedPart("{\"face\": true}")
                 .createdAt(LocalDateTime.now())
                 .build();
 
@@ -66,9 +66,8 @@ class DeepfakeDetectionServiceTest {
                 .deepfakeDetectionId(2L)
                 .user(mockUser)
                 .filePath("path2.mp4")
-                .deepfakeResult(0.3f)
+                .result(DeepfakeResult.REAL)
                 .riskScore(0.2f)
-                .detectedPart("{\"face\": false}")
                 .createdAt(LocalDateTime.now())
                 .build();
     }
@@ -90,7 +89,7 @@ class DeepfakeDetectionServiceTest {
         // then
         assertNotNull(result);
         assertEquals(uploadedUrl, result.getFilePath());
-        assertEquals(0.7F, result.getDeepfakeResult()); // 하드코딩 값 기준
+        assertEquals(DeepfakeResult.FAKE, result.getResult()); // 하드코딩 값 기준
         assertEquals(0.7F, result.getRiskScore());
 
         then(userRepository).should().findById(userId);
@@ -109,9 +108,8 @@ class DeepfakeDetectionServiceTest {
                 .deepfakeDetectionId(detectionId)
                 .user(mockUser)
                 .filePath("test/path.mp4")
-                .deepfakeResult(0.85f)
+                .result(DeepfakeResult.FAKE)
                 .riskScore(0.75f)
-                .detectedPart("{\"face\": true}")
                 .createdAt(LocalDateTime.now())
                 .build();
 
@@ -121,7 +119,7 @@ class DeepfakeDetectionServiceTest {
         DeepfakeDetectionDTO result = deepfakeDetectionService.getSingleResult(userId, detectionId);
 
         assertEquals("test/path.mp4", result.getFilePath());
-        assertEquals(0.85f, result.getDeepfakeResult());
+        assertEquals(DeepfakeResult.FAKE, result.getResult());
     }
 
     @Test


### PR DESCRIPTION
## 📝 Summary
- deepFakeResult 컬럼 Float 에서 Enum(real/fake)로 변경
- detectedPart 필드 삭제 

## 💻 Describe your changes
- deepFakeResult 를 REAL/FAKE로 반환할 수 있도록 Enum을 만들어 설정했습니다.
- 딥페이크 탐지 모델에서 자동으로 탐지 영역이 이미지로 출력되어 json 형식의 detectedPart가 필요 없어 삭제했습니다.
- 관련 DTO와 TEST 수정했습니다

## #️⃣ Issue number and link
> #39 

## 💬 Message to the Reviewer
