### PR TITLE
Feat: Flask 서버 연동해 결과 이미지 S3 저장

### DIFF
--- a/deeptruth/build.gradle
+++ b/deeptruth/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/FlaskResponseDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/FlaskResponseDTO.java
@@ -1,0 +1,16 @@
+package com.deeptruth.deeptruth.base.dto.deepfake;
+
+import com.deeptruth.deeptruth.base.Enum.DeepfakeResult;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FlaskResponseDTO {
+    private DeepfakeResult result;
+    private Float confidence;
+    private String base64Url;
+    private String imageUrl;
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebClientConfig.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebClientConfig.java
@@ -1,0 +1,13 @@
+package com.deeptruth.deeptruth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionController.java
@@ -1,12 +1,20 @@
 package com.deeptruth.deeptruth.controller;
 
 import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionDTO;
+import com.deeptruth.deeptruth.base.dto.deepfake.FlaskResponseDTO;
 import com.deeptruth.deeptruth.base.dto.response.ResponseDTO;
 import com.deeptruth.deeptruth.service.DeepfakeDetectionService;
+import com.deeptruth.deeptruth.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 
@@ -17,13 +25,56 @@ public class DeepfakeDetectionController {
 
     private final DeepfakeDetectionService deepfakeDetectionService;
 
-    @PostMapping
-    public ResponseEntity<ResponseDTO> uploadVideo(Long userId, @RequestPart("file")MultipartFile multipartFile){
-        DeepfakeDetectionDTO result = deepfakeDetectionService.uploadVideo(userId, multipartFile);
+    private final UserService userService;
 
-        return ResponseEntity.ok(
-                ResponseDTO.success(200, "딥페이크 탐지 영상 업로드 성공", result)
-        );
+    private final WebClient webClient;
+
+    @Value("${flask.server.url}")
+    private String flaskServerUrl;
+
+    @PostMapping
+    public ResponseEntity<ResponseDTO> detectVideo(Long userId, @RequestPart("file")MultipartFile multipartFile){
+        try {
+            if (!userService.existsByUserId(userId)) {
+                return ResponseEntity.status(404).body(ResponseDTO.fail(404, "존재하지 않는 사용자입니다."));
+            }
+
+            ByteArrayResource resource = new ByteArrayResource(multipartFile.getBytes()) {
+                @Override
+                public String getFilename() {
+                    return multipartFile.getOriginalFilename();
+                }
+            };
+
+            Mono<FlaskResponseDTO> flaskResponseMono = webClient.post()
+                    .uri(flaskServerUrl + "/predict")
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(BodyInserters.fromMultipartData("file", resource))
+                    .retrieve()
+                    .bodyToMono(FlaskResponseDTO.class);
+
+            FlaskResponseDTO flaskResult = flaskResponseMono.block();
+
+            if (flaskResult == null) {
+                return ResponseEntity.status(500).body(ResponseDTO.fail(500, "Flask 서버 응답 실패"));
+            }
+
+            String base64Image = flaskResult.getBase64Url();
+            String imageUrl = null;
+
+            if (base64Image != null && !base64Image.isEmpty()) {
+                imageUrl = deepfakeDetectionService.uploadBase64ImageToS3(base64Image, userId);
+                flaskResult.setImageUrl(imageUrl);
+            }
+
+            DeepfakeDetectionDTO dto = deepfakeDetectionService.createDetection(userId, flaskResult);
+
+            return ResponseEntity.ok(ResponseDTO.success(200, "딥페이크 탐지 결과 수신 성공", dto));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(500).body(ResponseDTO.fail(500, "서버 오류: " + e.getMessage()));
+        }
     }
 
     @GetMapping

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/repository/UserRepository.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/repository/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     boolean existsByNickname(String nickname);
+
+    boolean existsByUserId(Long userId);
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/AmazonS3Service.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/AmazonS3Service.java
@@ -54,4 +54,22 @@ public class AmazonS3Service {
         return uploadFileUrl;
     }
 
+    public String uploadBase64Image(InputStream inputStream, String key) {
+        try {
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType("image/jpeg");
+            metadata.setContentLength(inputStream.available());
+
+            amazonS3Client.putObject(
+                    new PutObjectRequest(bucketName, key, inputStream, metadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead)
+            );
+
+            return amazonS3Client.getUrl(bucketName, key).toString();
+        } catch (IOException e) {
+            log.error("이미지 업로드 실패", e);
+            throw new RuntimeException("S3 이미지 업로드 실패", e);
+        }
+    }
+
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/UserService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/UserService.java
@@ -41,4 +41,8 @@ public class UserService {
         }
         return nickname;
     }
+
+    public boolean existsByUserId(Long userId){
+        return userRepository.existsByUserId(userId);
+    }
 }


### PR DESCRIPTION
## 📝 Summary
- Deepfake Flask 서버와 연동
- 결과값으로 받은 Base64 uri를 디코딩해 S3에 저장

## 💻 Describe your changes
- 결과값을 저장한 후 DeepfakeDetectionDTO로 받아왔습니다

## #️⃣ Issue number and link
#40 

## 💬 Message to the Reviewer
- 시간 관계상 TDD로 개발하지 못하였습니다. 추후 테스트 코드 개발 예정입니다. 

