### PR TITLE
Feat: 워터마크 삽입 기록 조회 및 삭제 기능 구현

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermark/WatermarkDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermark/WatermarkDTO.java
@@ -1,0 +1,27 @@
+package com.deeptruth.deeptruth.base.dto.watermark;
+
+import com.deeptruth.deeptruth.entity.Watermark;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class WatermarkDTO {
+    private Long id;
+    private String originalFilePath;
+    private String watermarkedFilePath;
+    private LocalDateTime createdAt;
+
+    public static WatermarkDTO fromEntity(Watermark entity){
+        return WatermarkDTO.builder()
+                .id(entity.getWatermarkId())
+                .originalFilePath(entity.getOriginalFilePath())
+                .watermarkedFilePath(entity.getWatermarkedFilePath())
+                .createdAt(entity.getCreatedAt())
+                .build();
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/WatermarkController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/WatermarkController.java
@@ -1,0 +1,42 @@
+package com.deeptruth.deeptruth.controller;
+
+import com.deeptruth.deeptruth.base.dto.response.ResponseDTO;
+import com.deeptruth.deeptruth.base.dto.watermark.WatermarkDTO;
+import com.deeptruth.deeptruth.service.WatermarkService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/watermark")
+public class WatermarkController {
+
+    private final WatermarkService waterMarkService;
+
+
+    @GetMapping
+    public ResponseEntity<ResponseDTO> getAllWatermarks(@RequestParam Long userId){
+        List<WatermarkDTO> result = waterMarkService.getAllResult(userId);
+        return ResponseEntity.ok(
+                ResponseDTO.success(200, "워터마크 삽입 기록 전체 조회 성공", result)
+        );
+
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ResponseDTO> getWatermark(@PathVariable Long id, @RequestParam Long userId){
+        WatermarkDTO result = waterMarkService.getSingleResult(userId, id);
+        return ResponseEntity.ok(ResponseDTO.success(200, "워터마크 삽입 기록 조회 성공", result));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ResponseDTO> deleteWatermark(@PathVariable Long id, @RequestParam Long userId){
+        waterMarkService.deleteWatermark(userId, id);
+        return ResponseEntity.ok(
+                ResponseDTO.success(200, "워터마크 삽입 기록 삭제 성공", null)
+        );
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/repository/WatermarkRepository.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/repository/WatermarkRepository.java
@@ -1,0 +1,17 @@
+package com.deeptruth.deeptruth.repository;
+
+import com.deeptruth.deeptruth.entity.User;
+import com.deeptruth.deeptruth.entity.Watermark;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface WatermarkRepository extends JpaRepository<Watermark, Long> {
+    List<Watermark> findAllByUser(User user);
+    void deleteByWatermarkIdAndUser(Long id, User user);
+
+    Optional<Watermark> findByWatermarkIdAndUser(Long id, User user);
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
@@ -1,0 +1,43 @@
+package com.deeptruth.deeptruth.service;
+
+import com.deeptruth.deeptruth.base.dto.watermark.WatermarkDTO;
+import com.deeptruth.deeptruth.entity.User;
+import com.deeptruth.deeptruth.entity.Watermark;
+import com.deeptruth.deeptruth.repository.UserRepository;
+import com.deeptruth.deeptruth.repository.WatermarkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class WatermarkService {
+    private final WatermarkRepository watermarkRepository;
+    private final UserRepository userRepository;
+    private final AmazonS3Service amazonS3Service;
+
+    public List<WatermarkDTO> getAllResult(Long userId){
+        User user = userRepository.findById(userId).orElseThrow();
+        List<Watermark> results = watermarkRepository.findAllByUser(user);
+
+        return results.stream()
+                .map(WatermarkDTO::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public WatermarkDTO getSingleResult(Long userId, Long id){
+        User user = userRepository.findById(userId).orElseThrow();
+        Watermark mark = watermarkRepository.findByWatermarkIdAndUser(id, user).orElseThrow();
+
+        return WatermarkDTO.fromEntity(mark);
+    }
+
+    public void deleteWatermark(Long userId, Long id){
+        User user = userRepository.findById(userId).orElseThrow();
+        watermarkRepository.deleteByWatermarkIdAndUser(id, user);
+    }
+}

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionControllerTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionControllerTest.java
@@ -45,7 +45,6 @@ public class DeepfakeDetectionControllerTest {
         DeepfakeDetectionDTO mockDto = DeepfakeDetectionDTO.builder()
                 .filePath("https://s3.amazonaws.com/deepfake/video.mp4")
                 .result(deepfakeResult)
-                .riskScore(riskScore)
                 .build();
 
         given(deepfakeDetectionService.uploadVideo(eq(userId), any(MultipartFile.class)))
@@ -74,7 +73,6 @@ public class DeepfakeDetectionControllerTest {
                 .id(1L)
                 .filePath("test/path.mp4")
                 .result(DeepfakeResult.FAKE)
-                .riskScore(0.75f)
                 .createdAt(LocalDateTime.now())
                 .build();
 
@@ -101,7 +99,6 @@ public class DeepfakeDetectionControllerTest {
                 .id(id)
                 .filePath("test/path.mp4")
                 .result(DeepfakeResult.FAKE)
-                .riskScore(0.75f)
                 .createdAt(LocalDateTime.now())
                 .build();
 

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/WatermarkControllerTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/WatermarkControllerTest.java
@@ -1,0 +1,86 @@
+package com.deeptruth.deeptruth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(WatermarkController.class)
+public class WatermarkControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private WatermarkService waterMarkService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void getAllWatermarks_ShouldReturnList() throws Exception {
+        // given
+        Long userId = 1L;
+        WatermarkDTO dto1 = new WatermarkDTO(1L, "original1.jpg", "watermarked1.jpg", "2024-01-01T00:00:00");
+        WatermarkDTO dto2 = new WatermarkDTO(2L, "original2.jpg", "watermarked2.jpg", "2024-01-02T00:00:00");
+
+        Mockito.when(waterMarkService.getAllResult(userId)).thenReturn(List.of(dto1, dto2));
+
+        // when & then
+        mockMvc.perform(get("/watermark")
+                        .param("userId", String.valueOf(userId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("워터마크 삽입 기록 전체 조회 성공"))
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.data[0].originalFilePath").value("original1.jpg"));
+    }
+
+    @Test
+    void getWatermark_ShouldReturnOne() throws Exception {
+        // given
+        Long userId = 1L;
+        Long id = 42L;
+        WatermarkDTO dto = new WatermarkDTO(id, "original.jpg", "watermarked.jpg", "2024-01-01T00:00:00");
+
+        Mockito.when(waterMarkService.getSingleResult(userId, id)).thenReturn(dto);
+
+        // when & then
+        mockMvc.perform(get("/watermark/{id}", id)
+                        .param("userId", String.valueOf(userId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("워터마크 삽입 기록 조회 성공"))
+                .andExpect(jsonPath("$.data.originalFilePath").value("original.jpg"));
+    }
+
+    @Test
+    void deleteWatermark_ShouldSucceed() throws Exception {
+        // given
+        Long userId = 1L;
+        Long id = 10L;
+
+        // when & then
+        mockMvc.perform(delete("/watermark/{id}", id)
+                        .param("userId", String.valueOf(userId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("워터마크 삽입 기록 삭제 성공"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        Mockito.verify(waterMarkService).deleteWatermark(userId, id);
+    }
+}

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/WatermarkControllerTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/WatermarkControllerTest.java
@@ -1,24 +1,26 @@
 package com.deeptruth.deeptruth.controller;
 
+import com.deeptruth.deeptruth.base.dto.watermark.WatermarkDTO;
+import com.deeptruth.deeptruth.service.WatermarkService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.hamcrest.Matchers.*;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(WatermarkController.class)
+@WebMvcTest(controllers = WatermarkController.class)
+@AutoConfigureMockMvc(addFilters = false)
 public class WatermarkControllerTest {
 
     @Autowired
@@ -34,8 +36,8 @@ public class WatermarkControllerTest {
     void getAllWatermarks_ShouldReturnList() throws Exception {
         // given
         Long userId = 1L;
-        WatermarkDTO dto1 = new WatermarkDTO(1L, "original1.jpg", "watermarked1.jpg", "2024-01-01T00:00:00");
-        WatermarkDTO dto2 = new WatermarkDTO(2L, "original2.jpg", "watermarked2.jpg", "2024-01-02T00:00:00");
+        WatermarkDTO dto1 = new WatermarkDTO(1L, "original1.jpg", "watermarked1.jpg", LocalDateTime.parse("2024-01-01T00:00:00"));
+        WatermarkDTO dto2 = new WatermarkDTO(2L, "original2.jpg", "watermarked2.jpg", LocalDateTime.parse("2024-01-02T00:00:00"));
 
         Mockito.when(waterMarkService.getAllResult(userId)).thenReturn(List.of(dto1, dto2));
 
@@ -54,7 +56,7 @@ public class WatermarkControllerTest {
         // given
         Long userId = 1L;
         Long id = 42L;
-        WatermarkDTO dto = new WatermarkDTO(id, "original.jpg", "watermarked.jpg", "2024-01-01T00:00:00");
+        WatermarkDTO dto = new WatermarkDTO(id, "original.jpg", "watermarked.jpg", LocalDateTime.parse("2024-01-01T00:00:00"));
 
         Mockito.when(waterMarkService.getSingleResult(userId, id)).thenReturn(dto);
 

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/service/DeepfakeDetectionServiceTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/service/DeepfakeDetectionServiceTest.java
@@ -58,7 +58,6 @@ class DeepfakeDetectionServiceTest {
                 .user(mockUser)
                 .filePath("path1.mp4")
                 .result(DeepfakeResult.FAKE)
-                .riskScore(0.8f)
                 .createdAt(LocalDateTime.now())
                 .build();
 
@@ -67,7 +66,6 @@ class DeepfakeDetectionServiceTest {
                 .user(mockUser)
                 .filePath("path2.mp4")
                 .result(DeepfakeResult.REAL)
-                .riskScore(0.2f)
                 .createdAt(LocalDateTime.now())
                 .build();
     }
@@ -90,7 +88,6 @@ class DeepfakeDetectionServiceTest {
         assertNotNull(result);
         assertEquals(uploadedUrl, result.getFilePath());
         assertEquals(DeepfakeResult.FAKE, result.getResult()); // 하드코딩 값 기준
-        assertEquals(0.7F, result.getRiskScore());
 
         then(userRepository).should().findById(userId);
         then(amazonS3Service).should().uploadFile("deepfake", multipartFile);
@@ -109,7 +106,6 @@ class DeepfakeDetectionServiceTest {
                 .user(mockUser)
                 .filePath("test/path.mp4")
                 .result(DeepfakeResult.FAKE)
-                .riskScore(0.75f)
                 .createdAt(LocalDateTime.now())
                 .build();
 

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/service/WatermarkServiceTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/service/WatermarkServiceTest.java
@@ -1,8 +1,10 @@
 package com.deeptruth.deeptruth.service;
 
+import com.deeptruth.deeptruth.base.dto.watermark.WatermarkDTO;
 import com.deeptruth.deeptruth.entity.User;
 import com.deeptruth.deeptruth.entity.Watermark;
 import com.deeptruth.deeptruth.repository.UserRepository;
+import com.deeptruth.deeptruth.repository.WatermarkRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/service/WatermarkServiceTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/service/WatermarkServiceTest.java
@@ -1,0 +1,91 @@
+package com.deeptruth.deeptruth.service;
+
+import com.deeptruth.deeptruth.entity.User;
+import com.deeptruth.deeptruth.entity.Watermark;
+import com.deeptruth.deeptruth.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class WatermarkServiceTest {
+    @Mock
+    private WatermarkRepository watermarkRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private AmazonS3Service amazonS3Service;
+
+    @InjectMocks
+    private WatermarkService watermarkService;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getAllResult_ShouldReturnDTOList() {
+        // given
+        Long userId = 1L;
+        User user = new User();
+        List<Watermark> marks = List.of(
+                Watermark.builder().user(user).originalFilePath("a.jpg").watermarkedFilePath("b.jpg").build()
+        );
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(watermarkRepository.findAllByUser(user)).thenReturn(marks);
+
+        // when
+        List<WatermarkDTO> result = watermarkService.getAllResult(userId);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getOriginalFilePath()).isEqualTo("a.jpg");
+    }
+
+    @Test
+    void getSingleResult_ShouldReturnDTO() {
+        // given
+        Long userId = 1L;
+        Long markId = 2L;
+        User user = new User();
+        Watermark mark = Watermark.builder().originalFilePath("a.jpg").watermarkedFilePath("b.jpg").build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(watermarkRepository.findByWatermarkIdAndUser(markId, user)).thenReturn(Optional.of(mark));
+
+        // when
+        WatermarkDTO result = watermarkService.getSingleResult(userId, markId);
+
+        // then
+        assertThat(result.getOriginalFilePath()).isEqualTo("a.jpg");
+    }
+
+    @Test
+    void deleteWatermark_ShouldInvokeRepositoryDelete() {
+        // given
+        Long userId = 1L;
+        Long markId = 2L;
+        User user = new User();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // when
+        watermarkService.deleteWatermark(userId, markId);
+
+        // then
+        verify(watermarkRepository).deleteByWatermarkIdAndUser(markId, user);
+    }
+
+}


### PR DESCRIPTION
## 📝 Summary
- 워터마크 삽입 기록 전체 조회 기능
- 워터마크 삽입 기록 개별 조회 기능
- 워터마크 삽입 기록 삭제 기능

## 💻 Describe your changes
- WatermarkDTO를 이용해 기록 조회 가능합니다
- Watermark id를 이용해 개별 조회 및 삭제 가능합니다.
- 기능 관련 controllreTest 및 serviceTest 구현했습니다. 

## #️⃣ Issue number and link
> #45 

## 💬 Message to the Reviewer

