### PR TITLE
ETR 59 일반 로그인 기능 TDD 구현

### DIFF
--- a/.idea/dataSources.local.xml
+++ b/.idea/dataSources.local.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="dataSourceStorageLocal" created-in="IU-243.25659.59">
+  <component name="dataSourceStorageLocal" created-in="IU-243.26053.27">
     <data-source name="db_deeptruth@localhost" uuid="b677a7c2-cd2b-4afb-88aa-03f37e8c3ca3">
       <database-info product="" version="" jdbc-version="" driver-name="" driver-version="" dbms="MYSQL" />
       <user-name>root</user-name>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/BackEnd.iml" filepath="$PROJECT_DIR$/.idea/BackEnd.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/deeptruth.main.iml" filepath="$PROJECT_DIR$/.idea/modules/deeptruth.main.iml" />
     </modules>
   </component>
 </project>

--- a/deeptruth/build.gradle
+++ b/deeptruth/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/login/LoginRequestDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/login/LoginRequestDTO.java
@@ -1,0 +1,20 @@
+package com.deeptruth.deeptruth.base.dto.login;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequestDTO {
+
+    @NotBlank(message = "아이디를 입력해주세요.")
+    private String loginId;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/signup/SignupRequestDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/signup/SignupRequestDTO.java
@@ -1,4 +1,4 @@
-package com.deeptruth.deeptruth.base.dto;
+package com.deeptruth.deeptruth.base.dto.signup;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/constants/LoginConstants.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/constants/LoginConstants.java
@@ -1,0 +1,16 @@
+package com.deeptruth.deeptruth.constants;
+
+public class LoginConstants {
+    // 에러 메시지
+    public static final String EMPTY_LOGIN_ID_MESSAGE = "아이디를 입력해주세요.";
+    public static final String EMPTY_PASSWORD_MESSAGE = "비밀번호를 입력해주세요.";
+    public static final String USER_NOT_FOUND_MESSAGE = "존재하지 않는 아이디입니다.";
+    public static final String PASSWORD_MISMATCH_MESSAGE = "비밀번호가 일치하지 않습니다.";
+
+    // 성공 메시지
+    public static final String LOGIN_SUCCESS_MESSAGE = "로그인이 완료되었습니다.";
+
+    // JWT 클레임
+    public static final String USER_ID_CLAIM = "userId";
+    public static final String ROLE_CLAIM = "role";
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/constants/SignupConstants.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/constants/SignupConstants.java
@@ -1,0 +1,21 @@
+package com.deeptruth.deeptruth.constants;
+
+public class SignupConstants {
+    // 정규식 패턴
+    public static final String LOGIN_ID_PATTERN = "^[a-z0-9]{6,20}$";
+    public static final String PASSWORD_PATTERN = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*\\W).{8,30}$";
+    public static final String NICKNAME_PATTERN = "^[가-힣a-zA-Z0-9]{2,15}$";
+
+    // 에러 메시지
+    public static final String LOGIN_ID_ERROR_MESSAGE = "아이디는 6~20자의 영소문자 및 숫자만 가능합니다.";
+    public static final String PASSWORD_ERROR_MESSAGE = "비밀번호는 8~30자, 영대/소문자·숫자·특수문자를 모두 포함해야 합니다.";
+    public static final String NICKNAME_ERROR_MESSAGE = "닉네임은 2~15자, 공백 및 특수문자를 제외한 한글/영문/숫자만 가능합니다.";
+
+    // 중복 검사 에러 메시지
+    public static final String DUPLICATE_LOGIN_ID_MESSAGE = "이미 사용 중인 아이디입니다.";
+    public static final String DUPLICATE_NICKNAME_MESSAGE = "이미 사용 중인 닉네임입니다.";
+    public static final String DUPLICATE_EMAIL_MESSAGE = "이미 사용 중인 이메일입니다.";
+
+    // 성공 메시지
+    public static final String SIGNUP_SUCCESS_MESSAGE = "회원가입이 완료되었습니다.";
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/UserController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.deeptruth.deeptruth.controller;
 
-import com.deeptruth.deeptruth.base.dto.SignupRequestDTO;
+import com.deeptruth.deeptruth.base.dto.signup.SignupRequestDTO;
 import com.deeptruth.deeptruth.base.dto.response.ResponseDTO;
 import com.deeptruth.deeptruth.service.UserService;
 import lombok.RequiredArgsConstructor;

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/UserController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/UserController.java
@@ -12,6 +12,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.deeptruth.deeptruth.constants.LoginConstants.*;
+import static com.deeptruth.deeptruth.constants.SignupConstants.*;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -26,7 +29,7 @@ public class UserController {
         return ResponseEntity.ok(
                 ResponseDTO.success(
                         HttpStatus.OK.value(),
-                        "회원가입이 완료되었습니다.",
+                        SIGNUP_SUCCESS_MESSAGE,
                         null
                 )
         );
@@ -40,16 +43,15 @@ public class UserController {
             return ResponseEntity.ok(
                     ResponseDTO.success(
                             HttpStatus.OK.value(),
-                            "로그인이 완료되었습니다.",
+                            LOGIN_SUCCESS_MESSAGE,
                             jwtToken
                     )
             );
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(
-                    ResponseDTO.success(
+                    ResponseDTO.fail(
                             HttpStatus.BAD_REQUEST.value(),
-                            e.getMessage(),
-                            (String) null
+                            e.getMessage()
                     )
             );
         }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/UserController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.deeptruth.deeptruth.controller;
 
+import com.deeptruth.deeptruth.base.dto.login.LoginRequestDTO;
 import com.deeptruth.deeptruth.base.dto.signup.SignupRequestDTO;
 import com.deeptruth.deeptruth.base.dto.response.ResponseDTO;
 import com.deeptruth.deeptruth.service.UserService;
@@ -30,4 +31,28 @@ public class UserController {
                 )
         );
     }
+
+    @PostMapping("/login")
+    public ResponseEntity<ResponseDTO<String>> login(@RequestBody LoginRequestDTO loginRequestDTO) {
+        try {
+            String jwtToken = userService.login(loginRequestDTO);
+
+            return ResponseEntity.ok(
+                    ResponseDTO.success(
+                            HttpStatus.OK.value(),
+                            "로그인이 완료되었습니다.",
+                            jwtToken
+                    )
+            );
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(
+                    ResponseDTO.success(
+                            HttpStatus.BAD_REQUEST.value(),
+                            e.getMessage(),
+                            (String) null
+                    )
+            );
+        }
+    }
+
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/UserService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/UserService.java
@@ -1,10 +1,10 @@
 package com.deeptruth.deeptruth.service;
 
-import com.deeptruth.deeptruth.base.Enum.Level;
 import com.deeptruth.deeptruth.base.Enum.Role;
 import com.deeptruth.deeptruth.base.Enum.SocialLoginType;
 import com.deeptruth.deeptruth.base.OAuth.OAuth2UserInfo;
-import com.deeptruth.deeptruth.base.dto.SignupRequestDTO;
+import com.deeptruth.deeptruth.base.dto.login.LoginRequestDTO;
+import com.deeptruth.deeptruth.base.dto.signup.SignupRequestDTO;
 import com.deeptruth.deeptruth.entity.User;
 import com.deeptruth.deeptruth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -115,5 +115,9 @@ public class UserService {
         if (!nickname.matches(NICKNAME_PATTERN)) {
             throw new IllegalArgumentException(NICKNAME_ERROR_MESSAGE);
         }
+    }
+
+    public String login(LoginRequestDTO loginRequestDTO) {
+        throw new UnsupportedOperationException("아직 구현되지 않음");
     }
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/util/JwtUtil.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/util/JwtUtil.java
@@ -1,0 +1,33 @@
+package com.deeptruth.deeptruth.util;
+
+import com.deeptruth.deeptruth.entity.User;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+import static com.deeptruth.deeptruth.constants.LoginConstants.*;
+
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @Value("${jwt.expiration}")
+    private long jwtExpiration;
+
+    public String generateToken(User user) {
+        return Jwts.builder()
+                .setSubject(user.getLoginId())
+                .claim(USER_ID_CLAIM, user.getUserId())
+                .claim(ROLE_CLAIM, user.getRole())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + jwtExpiration))
+                .signWith(SignatureAlgorithm.HS256, jwtSecret)
+                .compact();
+    }
+}
+

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/UserControllerTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/UserControllerTest.java
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-import com.deeptruth.deeptruth.base.dto.SignupRequestDTO;
+import com.deeptruth.deeptruth.base.dto.signup.SignupRequestDTO;
 import com.deeptruth.deeptruth.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/UserControllerTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/UserControllerTest.java
@@ -1,11 +1,15 @@
 package com.deeptruth.deeptruth.controller;
 
+import static com.deeptruth.deeptruth.constants.LoginConstants.*;
+import static com.deeptruth.deeptruth.constants.SignupConstants.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
+import com.deeptruth.deeptruth.base.dto.login.LoginRequestDTO;
 import com.deeptruth.deeptruth.base.dto.signup.SignupRequestDTO;
 import com.deeptruth.deeptruth.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -46,10 +50,82 @@ public class UserControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("회원가입이 완료되었습니다."))
+                .andExpect(jsonPath("$.message").value(SIGNUP_SUCCESS_MESSAGE))
                 .andExpect(jsonPath("$.data").isEmpty());
 
         verify(userService).signup(any(SignupRequestDTO.class));
+    }
+
+    @Test
+    @DisplayName("로그인 API 성공 테스트")
+    void loginApiSuccess() throws Exception {
+        // given
+        LoginRequestDTO loginRequest = new LoginRequestDTO();
+        loginRequest.setLoginId("testuser123");
+        loginRequest.setPassword("Password1!");
+
+        when(userService.login(any(LoginRequestDTO.class)))
+                .thenReturn("mocked.jwt.token");
+
+        // when & then
+        mockMvc.perform(post("/api/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value(LOGIN_SUCCESS_MESSAGE))
+                .andExpect(jsonPath("$.data").value("mocked.jwt.token"));
+
+        verify(userService).login(any(LoginRequestDTO.class));
+    }
+
+    @Test
+    @DisplayName("로그인 API 실패 테스트 - 존재하지 않는 아이디")
+    void loginApiFailure_UserNotFound() throws Exception {
+        // given
+        LoginRequestDTO loginRequest = new LoginRequestDTO();
+        loginRequest.setLoginId("nonexistent");
+        loginRequest.setPassword("Password1!");
+
+        when(userService.login(any(LoginRequestDTO.class)))
+                .thenThrow(new IllegalArgumentException(USER_NOT_FOUND_MESSAGE));
+
+        // when & then
+        mockMvc.perform(post("/api/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(USER_NOT_FOUND_MESSAGE))
+                .andExpect(jsonPath("$.data").isEmpty());
+
+        verify(userService).login(any(LoginRequestDTO.class));
+    }
+
+    @Test
+    @DisplayName("로그인 API 실패 테스트 - 잘못된 비밀번호")
+    void loginApiFailure_InvalidPassword() throws Exception {
+        // given
+        LoginRequestDTO loginRequest = new LoginRequestDTO();
+        loginRequest.setLoginId("testuser123");
+        loginRequest.setPassword("wrongpassword");
+
+        when(userService.login(any(LoginRequestDTO.class)))
+                .thenThrow(new IllegalArgumentException(PASSWORD_MISMATCH_MESSAGE));
+
+        // when & then
+        mockMvc.perform(post("/api/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(PASSWORD_MISMATCH_MESSAGE))
+                .andExpect(jsonPath("$.data").isEmpty());
+
+        verify(userService).login(any(LoginRequestDTO.class));
     }
 
 }


### PR DESCRIPTION
## 📝 Summary
- 로그인 기능 TDD 방식 구현
- JWT 토큰 생성 및 인증 처리
- RESTful API 엔드포인트 (/api/login)

## 💻 Describe your changes
- 유효성 검사: 아이디/비밀번호 null/empty 체크
- 인증 처리: 사용자 존재 여부 및 비밀번호 일치 확인
- JWT 토큰: 로그인 성공 시 JWT 토큰 생성 반환
- API: UserController.login() 엔드포인트 구현
- 테스트: UserServiceTest, UserControllerTest 모든 케이스 통과
- 리팩토링: JWT 유틸리티 분리 및 상수 추출 

## #️⃣ Issue number and link
> #49 

## 💬 Message to the Reviewer
로그인 기능 구현하면서 코드 구조 개선한 부분들 설명드리겠습니다!

### util, constants 패키지 분리 이유
**JwtUtil 클래스 분리**
- 재사용성: 추후에 다른 서비스에서도 JWT 써야 할 때 편하게 쓸 수 있도록 분리했습니다.
- 단일 책임: UserService에서 JWT까지 다 하면 복잡해져서 분리했습니다.

**Constants 패키지 분리**
- 매직 스트링 제거: 하드코딩 문자열들 상수로 빼서 관리하기 쉽게 했습니다.
- 일관성: 같은 에러 메시지 여러 곳에서 써도 실수하지 않도록 수정했습니다.
- 확장성: 나중에 메시지 수정하거나 다국어 지원할 때 편할 것 같습니다.

추가로 궁금한 점 있으시면 언제든 말씀해 주세요~
