### PR TITLE
Feat: 워터마크 삽입 이미지 Flask 연동 및 S3 업로드 기능 추가

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermark/WatermarkFlaskResponseDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermark/WatermarkFlaskResponseDTO.java
@@ -1,0 +1,15 @@
+package com.deeptruth.deeptruth.base.dto.watermark;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WatermarkFlaskResponseDTO {
+    private String image_base64;
+    private String filename;
+    private String message;
+    private String watermarkedFilePath;
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
@@ -1,6 +1,7 @@
 package com.deeptruth.deeptruth.service;
 
 import com.deeptruth.deeptruth.base.dto.watermark.WatermarkDTO;
+import com.deeptruth.deeptruth.base.dto.watermark.WatermarkFlaskResponseDTO;
 import com.deeptruth.deeptruth.entity.User;
 import com.deeptruth.deeptruth.entity.Watermark;
 import com.deeptruth.deeptruth.repository.UserRepository;
@@ -9,7 +10,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.util.Base64;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -19,6 +25,29 @@ public class WatermarkService {
     private final WatermarkRepository watermarkRepository;
     private final UserRepository userRepository;
     private final AmazonS3Service amazonS3Service;
+
+    public WatermarkDTO createWatermark(Long userId, WatermarkFlaskResponseDTO dto){
+        User user = userRepository.findById(userId).orElseThrow();
+
+        Watermark watermark = Watermark.builder()
+                .user(user)
+                .watermarkedFilePath(dto.getWatermarkedFilePath())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        watermarkRepository.save(watermark);
+        return WatermarkDTO.fromEntity(watermark);
+    }
+
+    public String uploadBase64ImageToS3(String base64Image, Long userId) {
+        byte[] decodedBytes = Base64.getDecoder().decode(base64Image);
+        InputStream inputStream = new ByteArrayInputStream(decodedBytes);
+
+        String key = "watermark/marked/" + userId + "/" + UUID.randomUUID() + ".jpg";
+        String imageUrl = amazonS3Service.uploadBase64Image(inputStream, key);
+
+        return imageUrl;
+    }
 
     public List<WatermarkDTO> getAllResult(Long userId){
         User user = userRepository.findById(userId).orElseThrow();


### PR DESCRIPTION
## 📝 Summary
Flask에서 워터마크가 삽입된 이미지를 생성하고, 해당 이미지를 Spring 서버로 전달받아 S3에 업로드하는 기능을 구현했습니다.

## 💻 Describe your changes
- Spring `POST /watermark` 컨트롤러:
  - 클라이언트로부터 이미지와 메시지 수신
  - Flask 서버에 `multipart/form-data`로 요청 전송
  - 응답으로 받은 base64 이미지를 S3에 업로드
  - 업로드된 S3 URL을 DB에 저장 (`Watermark` 엔티티)

## #️⃣ Issue number and link
> #44 

## 💬 Message to the Reviewer
- Flask 워터마크 삽입 서버는 `localhost:5000` 기준으로 연동됐습니다
- 추후 배포 시 외부 도메인으로 `flaskServerUrl` 환경 변수 설정 필요합니다