### PR TITLE
Refactor: 딥페이크 전체 조회 API에 15건 단위 페이징 기능 추가

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionController.java
@@ -8,6 +8,10 @@ import com.deeptruth.deeptruth.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -78,8 +82,8 @@ public class DeepfakeDetectionController {
     }
 
     @GetMapping
-    public ResponseEntity<ResponseDTO> getAllDetections(@RequestParam Long userId){
-        List<DeepfakeDetectionDTO> result = deepfakeDetectionService.getAllResult(userId);
+    public ResponseEntity<ResponseDTO> getAllDetections(@RequestParam Long userId, @PageableDefault(size = 15, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable){
+        Page<DeepfakeDetectionDTO> result = deepfakeDetectionService.getAllResult(userId, pageable);
         return ResponseEntity.ok(
                 ResponseDTO.success(200, "딥페이크 탐지 결과 전체 조회 성공", result)
         );

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/repository/DeepfakeDetectionRepository.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/repository/DeepfakeDetectionRepository.java
@@ -3,6 +3,8 @@ package com.deeptruth.deeptruth.repository;
 import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionDTO;
 import com.deeptruth.deeptruth.entity.DeepfakeDetection;
 import com.deeptruth.deeptruth.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -13,5 +15,5 @@ public interface DeepfakeDetectionRepository extends JpaRepository<DeepfakeDetec
     Optional<DeepfakeDetection> findByDeepfakeDetectionIdAndUser(Long id, User user);
     void deleteByDeepfakeDetectionIdAndUser(Long id, User user);
     List<DeepfakeDetection> findAllByUser(User user);
-
+    Page<DeepfakeDetection> findByUser_UserId(Long userId, Pageable pageable);
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
@@ -9,6 +9,8 @@ import com.deeptruth.deeptruth.repository.DeepfakeDetectionRepository;
 import com.deeptruth.deeptruth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import net.minidev.json.JSONUtil;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -79,13 +81,9 @@ public class DeepfakeDetectionService {
         return imageUrl;
     }
 
-    public List<DeepfakeDetectionDTO> getAllResult(Long userId){
-        User user = userRepository.findById(userId).orElseThrow();
-        List<DeepfakeDetection> results = deepfakeDetectionRepository.findAllByUser(user);
-
-        return results.stream()
-                .map(DeepfakeDetectionDTO::fromEntity)
-                .collect(Collectors.toList());
+    public Page<DeepfakeDetectionDTO> getAllResult(Long userId, Pageable pageable){
+        return deepfakeDetectionRepository.findByUser_UserId(userId, pageable)
+                .map(DeepfakeDetectionDTO::fromEntity);
     }
 
     public DeepfakeDetectionDTO getSingleResult(Long userId, Long id) {

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionControllerTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionControllerTest.java
@@ -76,8 +76,8 @@ public class DeepfakeDetectionControllerTest {
                 .createdAt(LocalDateTime.now())
                 .build();
 
-        Mockito.when(deepfakeDetectionService.getAllResult(userId))
-                .thenReturn(List.of(dto));
+//        Mockito.when(deepfakeDetectionService.getAllResult(userId))
+//                .thenReturn(List.of(dto));
 
         mockMvc.perform(get("/deepfake")
                         .param("userId", String.valueOf(userId)))


### PR DESCRIPTION
## 📝 Summary
딥페이크 탐지 기록 전체 조회 시 결과가 많아지는 문제를 해결하기 위해, 15건 단위의 페이징 기능을 적용했습니다.

## 💻 Describe your changes
- `/deepfake` GET API에 `Pageable` 파라미터 적용
  - 기본 `page=0`, `size=15`, 정렬은 `createdAt DESC`
- 컨트롤러에서 `PageableDefault`를 사용해 기본값 설정
- 서비스 및 Repository 계층에 `Page<DeepfakeDetectionDTO>` 반환 방식 도입

## #️⃣ Issue number and link
> #34 

## 💬 Message to the Reviewer
