### PR TITLE
Fix: 잘못된 Pageable import 및 application.yml 설정 키 수정

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionController.java
@@ -33,7 +33,7 @@ public class DeepfakeDetectionController {
 
     private final WebClient webClient;
 
-    @Value("${flask.server.url}")
+    @Value("${flask.deepfakeServer.url}")
     private String flaskServerUrl;
 
     @PostMapping

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/WatermarkController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/WatermarkController.java
@@ -7,6 +7,7 @@ import com.deeptruth.deeptruth.service.UserService;
 import com.deeptruth.deeptruth.service.WatermarkService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.beans.factory.annotation.Value;
@@ -20,7 +21,6 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
-import java.awt.print.Pageable;
 import java.util.List;
 
 @RestController
@@ -33,7 +33,7 @@ public class WatermarkController {
     private final UserService userService;
     private final WebClient webClient;
 
-    @Value("${flask.watermark-server.url}")
+    @Value("${flask.watermarkServer.url}")
     private String flaskServerUrl;
 
     @PostMapping

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/repository/WatermarkRepository.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/repository/WatermarkRepository.java
@@ -3,10 +3,10 @@ package com.deeptruth.deeptruth.repository;
 import com.deeptruth.deeptruth.entity.User;
 import com.deeptruth.deeptruth.entity.Watermark;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.awt.print.Pageable;
 import java.util.List;
 import java.util.Optional;
 

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
@@ -8,10 +8,10 @@ import com.deeptruth.deeptruth.repository.UserRepository;
 import com.deeptruth.deeptruth.repository.WatermarkRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.awt.print.Pageable;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.time.LocalDateTime;


### PR DESCRIPTION
## 📝 Summary
- 잘못된 `Pageable` import (`java.awt.print.Pageable`) → `org.springframework.data.domain.Pageable`로 교체
- `application.yml`에서 잘못된 설정 키(`deekfake-server`, `watermark-server`)를 camelCase(`deepfakeServer`, `watermarkServer`)로 변경
- 관련 `@Value` 키도 함께 수정하여 Spring Boot 애플리케이션 부팅 오류 해결

## 💻 Describe your changes
1. `WatermarkRepository`에서 잘못 사용된 `Pageable` import 수정:
   - ❌ `java.awt.print.Pageable` → ✅ `org.springframework.data.domain.Pageable`
   - 해당 문제로 인해 Spring Data JPA가 query 메서드를 생성하지 못하고 `LinkageError` 및 `UnsatisfiedDependencyException` 발생함

2. `application.yml` 내 설정 키 변경:
   - ❌ `flask.deekfake-server.url` → ✅ `flask.deepfakeServer.url`
   - ❌ `flask.watermark-server.url` → ✅ `flask.watermarkServer.url`
   - Java에서 `@Value`로 주입받는 키와 불일치로 인해 Spring 부팅 실패 발생
   - 키 이름을 camelCase로 변경하여 하이픈 기반 매핑 오류 예방

3. 관련 `@Value` 어노테이션 키도 함께 수정:
   ```java
   @Value("${flask.deepfakeServer.url}")
   @Value("${flask.watermarkServer.url}")

## #️⃣ Issue number and link
#44 

## 💬 Message to the Reviewer