### PR TITLE
Feat: OAuth2 소셜 로그인 연동 및 JWT 발급/저장 가능 구현

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/OAuth2AuthenticationSuccessHandler.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,103 @@
+package com.deeptruth.deeptruth.config;
+
+import com.deeptruth.deeptruth.base.OAuth.GoogleUserDetails;
+import com.deeptruth.deeptruth.base.OAuth.KakaoUserDetails;
+import com.deeptruth.deeptruth.base.OAuth.NaverUserDetails;
+import com.deeptruth.deeptruth.base.OAuth.OAuth2UserInfo;
+import com.deeptruth.deeptruth.entity.RefreshToken;
+import com.deeptruth.deeptruth.entity.User;
+import com.deeptruth.deeptruth.repository.RefreshTokenRepository;
+import com.deeptruth.deeptruth.repository.UserRepository;
+import com.deeptruth.deeptruth.util.JwtUtil;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Component
+@Slf4j
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public OAuth2AuthenticationSuccessHandler(JwtUtil jwtUtil,
+                                              UserRepository userRepository,
+                                              RefreshTokenRepository refreshTokenRepository) {
+        this.jwtUtil = jwtUtil;
+        this.userRepository = userRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication)
+            throws IOException, ServletException {
+
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        String provider = resolveProvider(authentication);
+        OAuth2UserInfo userInfo = getOAuth2UserInfo(provider, attributes);
+
+        // 이미 로그인 성공 시점에서 회원가입 또는 조회된 상태
+        User user = userRepository.findByEmail(userInfo.getEmail())
+                .orElseThrow(() -> new RuntimeException("User not found after OAuth2 login"));
+
+        // JWT 발급
+        String accessToken = jwtUtil.generateAccessToken(user);
+        String refreshTokenStr = jwtUtil.generateRefreshToken(user);
+
+        // RefreshToken 저장 또는 갱신
+        refreshTokenRepository.findByUser(user).ifPresentOrElse(
+                existing -> {
+                    existing.setToken(refreshTokenStr);
+                    existing.setCreatedAt(LocalDateTime.now());
+                    refreshTokenRepository.save(existing);
+                },
+                () -> {
+                    RefreshToken newToken = RefreshToken.builder()
+                            .user(user)
+                            .token(refreshTokenStr)
+                            .build();
+                    refreshTokenRepository.save(newToken);
+                }
+        );
+
+        String redirectUrl = UriComponentsBuilder.fromUriString("http://localhost:3000/oauth2/redirect")
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshTokenStr)
+                .build().toUriString();
+
+        response.sendRedirect(redirectUrl);
+    }
+
+
+    private String resolveProvider(Authentication authentication) {
+        if (authentication instanceof OAuth2AuthenticationToken oAuth2Token) {
+            return oAuth2Token.getAuthorizedClientRegistrationId(); // "kakao", "google" 등
+        }
+        return "unknown"; // fallback
+    }
+
+    private OAuth2UserInfo getOAuth2UserInfo(String provider, Map<String, Object> attributes) {
+        return switch (provider.toLowerCase()) {
+            case "google" -> new GoogleUserDetails(attributes);
+            case "kakao" -> new KakaoUserDetails(attributes);
+            case "naver" -> new NaverUserDetails(attributes);
+            default -> throw new RuntimeException("Unsupported provider: " + provider);
+        };
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/SecurityConfig.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/SecurityConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -18,6 +17,8 @@ public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler; // ✅ 주입
+
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -40,6 +41,7 @@ public class SecurityConfig {
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(customOAuth2UserService)
                         )
+                        .successHandler(oAuth2AuthenticationSuccessHandler)
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .csrf(csrf -> csrf.disable());  // ⚡ CSRF 보호 비활성화 (POST 요청 가능)


### PR DESCRIPTION
## 📝 Summary
OAuth2AuthenticationSuccessHandler에서 로그인 성공 시 JWT 발급 및 프론트 리디렉션 처리

## 💻 Describe your changes
- 카카오, 네이버, 구글 OAuth2 로그인 연동
- 로그인 성공 시 JWT AccessToken / RefreshToken 발급
- RefreshToken 엔티티 및 저장 로직 구현
- 소셜 로그인 성공 후 프론트엔드로 access/refresh 토큰 리디렉션

| 단계 | 설명 |
|------|------|
| 1 | 프론트에서 `/oauth2/authorization/{provider}` (예: kakao)로 이동 |
| 2 | 소셜 로그인 완료 후 백엔드에서 토큰 발급 |
| 3 | 백엔드는 `http://localhost:3000/oauth2/redirect?accessToken=...&refreshToken=...` 로 리디렉션 |
| 4 | 프론트는 리디렉션된 URL에서 토큰 추출 → 저장 (localStorage or cookie 등) |
| 5 | 이후 API 요청 시 `Authorization: Bearer {accessToken}` 헤더로 인증 |


## #️⃣ Issue number and link
#31 

## 💬 Message to the Reviewer
🧪 테스트 방법
1. 브라우저에서 `http://localhost:8080/oauth2/authorization/kakao` 접속
2. 소셜 로그인 진행 → accessToken / refreshToken 리디렉션 확인
3. Postman에서 다음 요청으로 검증:
GET /users/profile
Authorization: Bearer {AccessToken}