### PR TITLE
Feat: 진행률 WebSocket 중계 및 taskId 전달 플로우 추가

### DIFF
--- a/deeptruth/build.gradle
+++ b/deeptruth/build.gradle
@@ -47,6 +47,11 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+	implementation 'org.springframework.boot:spring-boot-starter'
 }
 
 tasks.named('test') {

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/websocket/ProgressDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/websocket/ProgressDTO.java
@@ -1,0 +1,11 @@
+package com.deeptruth.deeptruth.base.dto.websocket;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ProgressDTO {
+    private String taskId;
+    private int progress;
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebSocketConfig.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package com.deeptruth.deeptruth.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic");
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOrigins("http://localhost:8080", "http://127.0.0.1:8080",
+                        "http://localhost:3000", "http://127.0.0.1:3000")
+                .withSockJS();
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/ProgressController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/ProgressController.java
@@ -1,0 +1,27 @@
+package com.deeptruth.deeptruth.controller;
+
+import com.deeptruth.deeptruth.base.dto.websocket.ProgressDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/progress")
+public class ProgressController {
+    private final SimpMessagingTemplate messagingTemplate;
+
+    // Flask에서 전송: POST /progress
+    @PostMapping
+    public ResponseEntity<Void> receiveProgress(@RequestBody ProgressDTO progressDto) {
+        messagingTemplate.convertAndSend(
+                "/topic/progress/" + progressDto.getTaskId(),
+                progressDto
+        );
+        return ResponseEntity.ok().build();
+    }
+}

--- a/deeptruth/src/main/resources/static/test-client.html
+++ b/deeptruth/src/main/resources/static/test-client.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>WebSocket Progress Test</title>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+</head>
+<body>
+<h2>진행률: <span id="progress">-</span>%</h2>
+<script>
+    const socket = new SockJS("http://localhost:8080/ws");
+    const stompClient = Stomp.over(socket);
+    const taskId = "test-task";
+
+    stompClient.connect({}, () => {
+      console.log("Connected");
+
+      stompClient.subscribe(`/topic/progress/${taskId}`, (message) => {
+        const data = JSON.parse(message.body);
+        document.getElementById("progress").textContent = data.progress;
+      });
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📝 Summary
WebSocket 기반 진행률 전송 기능 추가했습니다. Flask 서버에서 전송한 진행률 데이터를 Spring이 수신하고, 구독 중인 클라이언트에게 실시간 브로드캐스트합니다.

## 💻 Describe your changes
* `ProgressController` 추가
  * `POST /progress` 요청 수신 후 `/topic/progress/{taskId}`로 WebSocket 브로드캐스트
* `SimpMessagingTemplate` 사용해 STOMP 구독자에게 진행률 전송
* CORS 설정에서 `allowedOriginPatterns` 사용해 credentials 허용
* 테스트용 정적 페이지 추가(test-client.html)
<img width="1917" height="1016" alt="1" src="https://github.com/user-attachments/assets/3c180f4f-4633-4298-a4e2-0c392d67411b" />

## #️⃣ Issue number and link
#58 

## 💬 Message to the Reviewer
현재는 딥페이크 분석 진행률만 연동했지만, 앞으로 다른 AI 기능들도 동일한 ProgressController를 재사용하면 별도의 컨트롤러 추가 없이 /progress API와 WebSocket 채널을 공통으로 활용할 수 있습니다.