### PR TITLE
originalFilePath 필드 제거 및 JWT 인증 적용

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermark/WatermarkDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermark/WatermarkDTO.java
@@ -12,14 +12,12 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class WatermarkDTO {
     private Long id;
-    private String originalFilePath;
     private String watermarkedFilePath;
     private LocalDateTime createdAt;
 
     public static WatermarkDTO fromEntity(Watermark entity){
         return WatermarkDTO.builder()
                 .id(entity.getWatermarkId())
-                .originalFilePath(entity.getOriginalFilePath())
                 .watermarkedFilePath(entity.getWatermarkedFilePath())
                 .createdAt(entity.getCreatedAt())
                 .build();

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/Watermark.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/Watermark.java
@@ -22,9 +22,6 @@ public class Watermark {
     private User user;
 
     @Column(nullable=false, length = 255)
-    private String originalFilePath;
-
-    @Column(nullable=false, length = 255)
     private String watermarkedFilePath;
 
     @Column(nullable=false, updatable = false)


### PR DESCRIPTION
## 📝 Summary
- 더 이상 originalFilePath가 사용되지 않아 엔티티/스키마에서 제거합니다.
- API 보호를 위해 JWT 기반 인증/인가를 추가했습니다.

## 💻 Describe your changes
1. Entity/DB
- watermark.original_file_path 컬럼 제거
- 관련 DTO 수정

2. POST /watermark API 변경
- Authorization: Bearer <token> 필요

## #️⃣ Issue number and link
#44 

## 💬 Message to the Reviewer
MySQL에서 아래와 같은 작업 필요합니다! 
`ALTER TABLE watermark DROP COLUMN IF EXISTS original_file_path;
`