### PR TITLE
Feat: 커스텀 예외 추가 및 GlobalExceptionHandler 구현; Refacotr: 에러 처리를 위한 deepfake & watermark service 수정

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/DetectionNotFoundException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/DetectionNotFoundException.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class DetectionNotFoundException extends RuntimeException {
+    public DetectionNotFoundException(Long detectionId, Long userId) {
+        super("Deepfake detection not found. id=" + detectionId + ", userId=" + userId);
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/ExternalServiceException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/ExternalServiceException.java
@@ -1,0 +1,5 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class ExternalServiceException extends RuntimeException {
+    public ExternalServiceException(String reason) { super("External service error: " + reason); }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/GlobalExceptionHandler.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/GlobalExceptionHandler.java
@@ -1,16 +1,19 @@
 package com.deeptruth.deeptruth.base.exception;
 
 import com.deeptruth.deeptruth.base.dto.response.ResponseDTO;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     // 404 - 리소스 없음
-    @ExceptionHandler({UserNotFoundException.class, DetectionNotFoundException.class})
+    @ExceptionHandler({UserNotFoundException.class, DetectionNotFoundException.class,  WatermarkNotFoundException.class})
     public ResponseEntity<ResponseDTO> handleNotFound(RuntimeException ex) {
+        log.info("[404] {}", ex.getMessage());
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
                 .body(ResponseDTO.fail(404, ex.getMessage()));
@@ -19,14 +22,16 @@ public class GlobalExceptionHandler {
     // 400 - 잘못된 요청
     @ExceptionHandler({InvalidFileException.class, ImageDecodingException.class})
     public ResponseEntity<ResponseDTO> handleBadRequest(RuntimeException ex) {
+        log.info("[400] {}", ex.getMessage());
         return ResponseEntity
                 .badRequest()
                 .body(ResponseDTO.fail(400, ex.getMessage()));
     }
 
     // 422 - 처리할 수 없는 엔티티 (유효성은 맞지만 비즈니스 규칙 위반)
-    @ExceptionHandler(InvalidDetectionResponseException.class)
+    @ExceptionHandler({InvalidDetectionResponseException.class, InvalidWatermarkResponseException.class})
     public ResponseEntity<ResponseDTO> handleUnprocessableEntity(RuntimeException ex) {
+        log.info("[422] {}", ex.getMessage());
         return ResponseEntity
                 .status(HttpStatus.UNPROCESSABLE_ENTITY)
                 .body(ResponseDTO.fail(422, ex.getMessage()));
@@ -35,6 +40,7 @@ public class GlobalExceptionHandler {
     // 5xx - 서버/외부 연동 문제
     @ExceptionHandler({StorageException.class, ExternalServiceException.class})
     public ResponseEntity<ResponseDTO> handleServerError(RuntimeException ex) {
+        log.error("[502] {}", ex.getMessage(), ex);
         return ResponseEntity
                 .status(HttpStatus.BAD_GATEWAY)
                 .body(ResponseDTO.fail(502, ex.getMessage()));
@@ -43,6 +49,7 @@ public class GlobalExceptionHandler {
     // 그 외 모든 예외 - 500
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ResponseDTO> handleGeneral(Exception ex) {
+        log.error("[500] {}", ex.getMessage(), ex);
         // 로그 남기기
         ex.printStackTrace();
         return ResponseEntity

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/GlobalExceptionHandler.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/GlobalExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.deeptruth.deeptruth.base.exception;
+
+import com.deeptruth.deeptruth.base.dto.response.ResponseDTO;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    // 404 - 리소스 없음
+    @ExceptionHandler({UserNotFoundException.class, DetectionNotFoundException.class})
+    public ResponseEntity<ResponseDTO> handleNotFound(RuntimeException ex) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ResponseDTO.fail(404, ex.getMessage()));
+    }
+
+    // 400 - 잘못된 요청
+    @ExceptionHandler({InvalidFileException.class, ImageDecodingException.class})
+    public ResponseEntity<ResponseDTO> handleBadRequest(RuntimeException ex) {
+        return ResponseEntity
+                .badRequest()
+                .body(ResponseDTO.fail(400, ex.getMessage()));
+    }
+
+    // 422 - 처리할 수 없는 엔티티 (유효성은 맞지만 비즈니스 규칙 위반)
+    @ExceptionHandler(InvalidDetectionResponseException.class)
+    public ResponseEntity<ResponseDTO> handleUnprocessableEntity(RuntimeException ex) {
+        return ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(ResponseDTO.fail(422, ex.getMessage()));
+    }
+
+    // 5xx - 서버/외부 연동 문제
+    @ExceptionHandler({StorageException.class, ExternalServiceException.class})
+    public ResponseEntity<ResponseDTO> handleServerError(RuntimeException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_GATEWAY)
+                .body(ResponseDTO.fail(502, ex.getMessage()));
+    }
+
+    // 그 외 모든 예외 - 500
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ResponseDTO> handleGeneral(Exception ex) {
+        // 로그 남기기
+        ex.printStackTrace();
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ResponseDTO.fail(500, "서버 내부 오류가 발생했습니다."));
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/ImageDecodingException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/ImageDecodingException.java
@@ -1,0 +1,5 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class ImageDecodingException extends RuntimeException {
+    public ImageDecodingException(String reason) { super("Failed to decode Base64 image: " + reason); }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/InvalidDetectionResponseException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/InvalidDetectionResponseException.java
@@ -1,0 +1,5 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class InvalidDetectionResponseException extends RuntimeException {
+    public InvalidDetectionResponseException(String reason) { super("Invalid detection response: " + reason); }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/InvalidFileException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/InvalidFileException.java
@@ -1,0 +1,5 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class InvalidFileException extends RuntimeException {
+    public InvalidFileException(String reason) { super("Invalid file: " + reason); }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/InvalidWatermarkResponseException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/InvalidWatermarkResponseException.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class InvalidWatermarkResponseException extends RuntimeException {
+    public InvalidWatermarkResponseException(String reason) {
+        super("Invalid watermark response: " + reason);
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/StorageException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/StorageException.java
@@ -1,0 +1,5 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class StorageException extends RuntimeException {
+    public StorageException(String reason, Throwable cause) { super("Storage error: " + reason, cause); }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/UserNotFoundException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class UserNotFoundException  extends RuntimeException {
+    public UserNotFoundException(Long userId) {
+        super("User not found. id=" + userId);
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/WatermarkNotFoundException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/WatermarkNotFoundException.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class WatermarkNotFoundException extends RuntimeException {
+    public WatermarkNotFoundException(Long watermarkId, Long userId) {
+        super("Watermark not found. id=" + watermarkId + ", userId=" + userId);
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/repository/DeepfakeDetectionRepository.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/repository/DeepfakeDetectionRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public interface DeepfakeDetectionRepository extends JpaRepository<DeepfakeDetection, Long> {
     void deleteByDeepfakeDetectionId(Long id);
     Optional<DeepfakeDetection> findByDeepfakeDetectionIdAndUser(Long id, User user);
-    void deleteByDeepfakeDetectionIdAndUser(Long id, User user);
+    int deleteByDeepfakeDetectionIdAndUser(Long id, User user);
     List<DeepfakeDetection> findAllByUser(User user);
     Page<DeepfakeDetection> findByUser_UserId(Long userId, Pageable pageable);
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/repository/WatermarkRepository.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/repository/WatermarkRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 @Repository
 public interface WatermarkRepository extends JpaRepository<Watermark, Long> {
     List<Watermark> findAllByUser(User user);
-    void deleteByWatermarkIdAndUser(Long id, User user);
+    int deleteByWatermarkIdAndUser(Long id, User user);
 
     Optional<Watermark> findByWatermarkIdAndUser(Long id, User user);
 

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
@@ -3,6 +3,7 @@ package com.deeptruth.deeptruth.service;
 import com.deeptruth.deeptruth.base.Enum.DeepfakeResult;
 import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionDTO;
 import com.deeptruth.deeptruth.base.dto.deepfake.FlaskResponseDTO;
+import com.deeptruth.deeptruth.base.exception.*;
 import com.deeptruth.deeptruth.entity.DeepfakeDetection;
 import com.deeptruth.deeptruth.entity.User;
 import com.deeptruth.deeptruth.repository.DeepfakeDetectionRepository;
@@ -34,68 +35,74 @@ public class DeepfakeDetectionService {
 
     private final AmazonS3Service amazonS3Service;
 
-    public DeepfakeDetectionDTO uploadVideo(Long userId, MultipartFile multipartFile){
-        User user = userRepository.findById(userId).orElseThrow();
-        String filePath = amazonS3Service.uploadFile("deepfake", multipartFile);
+    public DeepfakeDetectionDTO createDetection(Long userId, FlaskResponseDTO dto){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
 
-        DeepfakeResult deepfakeResult = DeepfakeResult.FAKE;
-        Float riskScore = 0.7F;
+        if (dto == null) throw new InvalidDetectionResponseException("response is null");
+        if (dto.getResult() == null) throw new InvalidDetectionResponseException("result is null");
+        if (dto.getImageUrl() == null || dto.getImageUrl().isBlank())
+            throw new InvalidDetectionResponseException("imageUrl is blank");
+        if (dto.getAverageConfidence() != null &&
+                (dto.getAverageConfidence() < 0 || dto.getAverageConfidence() > 1))
+            throw new InvalidDetectionResponseException("averageConfidence out of [0,1]");
+        if (dto.getMaxConfidence() != null &&
+                (dto.getMaxConfidence() < 0 || dto.getMaxConfidence() > 1))
+            throw new InvalidDetectionResponseException("maxConfidence out of [0,1]");
 
-
-        DeepfakeDetection detection = DeepfakeDetection.builder()
-                .user(user)
-                .filePath(filePath)
-                .result(deepfakeResult)
-                .build();
-
-        deepfakeDetectionRepository.save(detection);
-
-        DeepfakeDetectionDTO dto = DeepfakeDetectionDTO.fromEntity(detection);
-
-        return dto;
-    }
-
-    public DeepfakeDetectionDTO createDetection(Long userId, FlaskResponseDTO flaskResponseDTO){
-        User user = userRepository.findById(userId).orElseThrow();
 
         DeepfakeDetection detection = DeepfakeDetection.builder()
                 .user(user)
-                .filePath(flaskResponseDTO.getImageUrl())
-                .result(flaskResponseDTO.getResult())
-                .averageConfidence(flaskResponseDTO.getAverageConfidence())
-                .maxConfidence(flaskResponseDTO.getMaxConfidence())
+                .filePath(dto.getImageUrl())
+                .result(dto.getResult())
+                .averageConfidence(dto.getAverageConfidence())
+                .maxConfidence(dto.getMaxConfidence())
                 .build();
 
         deepfakeDetectionRepository.save(detection);
-
         return DeepfakeDetectionDTO.fromEntity(detection);
     }
 
     public String uploadBase64ImageToS3(String base64Image, Long userId) {
-        byte[] decodedBytes = Base64.getDecoder().decode(base64Image);
-        InputStream inputStream = new ByteArrayInputStream(decodedBytes);
+        userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
+        final byte[] decodedBytes;
+        try {
+            decodedBytes = Base64.getDecoder().decode(base64Image);
+        } catch (IllegalArgumentException e) {
+            throw new ImageDecodingException("invalid base64");
+        }
 
-        String key = "deepfake/" + userId + "/" + UUID.randomUUID() + ".jpg";
-        String imageUrl = amazonS3Service.uploadBase64Image(inputStream, key);
-
-        return imageUrl;
+        try (InputStream inputStream = new ByteArrayInputStream(decodedBytes)) {
+            String key = "deepfake/" + userId + "/" + UUID.randomUUID() + ".jpg";
+            return amazonS3Service.uploadBase64Image(inputStream, key);
+        } catch (Exception e) {
+            throw new StorageException("failed to upload image to S3", e);
+        }
     }
 
     public Page<DeepfakeDetectionDTO> getAllResult(Long userId, Pageable pageable){
+        userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
         return deepfakeDetectionRepository.findByUser_UserId(userId, pageable)
                 .map(DeepfakeDetectionDTO::fromEntity);
     }
 
     public DeepfakeDetectionDTO getSingleResult(Long userId, Long id) {
-        User user = userRepository.findById(userId).orElseThrow();
-        DeepfakeDetection detection = deepfakeDetectionRepository.findByDeepfakeDetectionIdAndUser(id, user).orElseThrow();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        DeepfakeDetection detection = deepfakeDetectionRepository
+                .findByDeepfakeDetectionIdAndUser(id, user)
+                .orElseThrow(() -> new DetectionNotFoundException(id, userId));
 
         return DeepfakeDetectionDTO.fromEntity(detection);
     }
 
     public void deleteResult(Long userId, Long id){
-        User user = userRepository.findById(userId).orElseThrow();
-
-        deepfakeDetectionRepository.deleteByDeepfakeDetectionIdAndUser(id, user);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+        int deleted = deepfakeDetectionRepository.deleteByDeepfakeDetectionIdAndUser(id, user);
+        if (deleted == 0) {
+            throw new DetectionNotFoundException(id, userId);
+        }
     }
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
@@ -2,6 +2,7 @@ package com.deeptruth.deeptruth.service;
 
 import com.deeptruth.deeptruth.base.dto.watermark.WatermarkDTO;
 import com.deeptruth.deeptruth.base.dto.watermark.WatermarkFlaskResponseDTO;
+import com.deeptruth.deeptruth.base.exception.*;
 import com.deeptruth.deeptruth.entity.User;
 import com.deeptruth.deeptruth.entity.Watermark;
 import com.deeptruth.deeptruth.repository.UserRepository;
@@ -29,7 +30,15 @@ public class WatermarkService {
     private final AmazonS3Service amazonS3Service;
       
     public WatermarkDTO createWatermark(Long userId, WatermarkFlaskResponseDTO dto){
-        User user = userRepository.findById(userId).orElseThrow();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        if (dto == null) {
+            throw new InvalidWatermarkResponseException("dto is null");
+        }
+        if (dto.getWatermarkedFilePath() == null || dto.getWatermarkedFilePath().isBlank()) {
+            throw new InvalidWatermarkResponseException("watermarkedFilePath is blank");
+        }
 
         Watermark watermark = Watermark.builder()
                 .user(user)
@@ -42,29 +51,45 @@ public class WatermarkService {
     }
 
     public String uploadBase64ImageToS3(String base64Image, Long userId) {
-        byte[] decodedBytes = Base64.getDecoder().decode(base64Image);
-        InputStream inputStream = new ByteArrayInputStream(decodedBytes);
+        if (base64Image == null || base64Image.isBlank()) {
+            throw new ImageDecodingException("empty string");
+        }
 
-        String key = "watermark/marked/" + userId + "/" + UUID.randomUUID() + ".jpg";
-        String imageUrl = amazonS3Service.uploadBase64Image(inputStream, key);
+        final byte[] decodedBytes;
+        try {
+            decodedBytes = Base64.getDecoder().decode(base64Image);
+        } catch (IllegalArgumentException e) {
+            throw new ImageDecodingException("malformed base64");
+        }
 
-        return imageUrl;
+        try (InputStream inputStream = new ByteArrayInputStream(decodedBytes)) {
+            String key = "watermark/marked/" + userId + "/" + UUID.randomUUID() + ".jpg";
+            return amazonS3Service.uploadBase64Image(inputStream, key);
+        } catch (Exception e) {
+            // S3 업로드 실패 → 5xx
+            throw new StorageException("failed to upload image to S3", e);
+        }
     }
   
     public Page<WatermarkDTO> getAllResult(Long userId, Pageable pageable){
+        userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
         return watermarkRepository.findByUser_UserId(userId, pageable)
                 .map(WatermarkDTO::fromEntity);
     }
 
     public WatermarkDTO getSingleResult(Long userId, Long id){
-        User user = userRepository.findById(userId).orElseThrow();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
         Watermark mark = watermarkRepository.findByWatermarkIdAndUser(id, user).orElseThrow();
 
         return WatermarkDTO.fromEntity(mark);
     }
 
     public void deleteWatermark(Long userId, Long id){
-        User user = userRepository.findById(userId).orElseThrow();
-        watermarkRepository.deleteByWatermarkIdAndUser(id, user);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        int deleted = watermarkRepository.deleteByWatermarkIdAndUser(id, user);
+        if (deleted == 0) throw new WatermarkNotFoundException(id, userId);
     }
 }


### PR DESCRIPTION
## 📝 Summary
- 도메인 맞춤 **커스텀 예외** 추가 및 **GlobalExceptionHandler** 도입으로 API 에러 응답 일원화
- **DeepfakeDetectionService**, **WatermarkService** 리팩터링: 서비스 계층에서 의미 있는 예외를 던지고 컨트롤러는 얇게 유지
- 스토리지/외부 연동/입력 유효성/리소스 없음 등 상황별 **HTTP 상태 코드 명확화**

## 💻 Describe your changes
### 1) Custom Exceptions 추가
- `UserNotFoundException` (404)
- `DetectionNotFoundException` (404)
- `WatermarkNotFoundException` (404)
- `InvalidFileException` (400)
- `ImageDecodingException` (400)
- `InvalidDetectionResponseException` (422)
- `InvalidWatermarkResponseException` (422)
- `StorageException` (5xx)
- `ExternalServiceException` (5xx)

> 목적: 예외 의미를 명시적으로 표현하고, GlobalExceptionHandler에서 상태 코드/응답 포맷을 일관되게 반환.

### 2) GlobalExceptionHandler 추가
- `@RestControllerAdvice` 기반 전역 예외 처리기
- 매핑 규칙
  - 404: `UserNotFoundException`, `DetectionNotFoundException`, `WatermarkNotFoundException`
  - 400: `InvalidFileException`, `ImageDecodingException`, 바인딩/검증 오류(`MethodArgumentNotValidException` 등)
  - 422: `InvalidDetectionResponseException`, `InvalidWatermarkResponseException`
  - 5xx/외부: `StorageException`, `ExternalServiceException` → 502 (팀 컨벤션)
  - 401/403: Spring Security 예외 매핑
  - 기타: 500
- 응답 포맷: `ResponseDTO.fail(code, message[, data])` 사용

### 3) DeepfakeDetectionService 리팩터링
- 변경 사항
  - `userRepository.findById` 실패 시 `UserNotFoundException` 던짐
  - 업로드 파일 유효성 검사(`null/empty`, `contentType` 확인) → `InvalidFileException`
  - Flask 응답 검증(필수 필드, confidence 범위 등) → `InvalidDetectionResponseException`
  - Base64 디코딩 실패 → `ImageDecodingException`
  - S3 업로드 실패 등 인프라 이슈 → `StorageException`
  - Flask 응답 null/통신 이상 → `ExternalServiceException`
- 효과
  - 컨트롤러에서 `try/catch` 제거 가능
  - 실패 원인에 따른 정확한 HTTP 코드/메시지 반환

### 4) WatermarkService 리팩터링
- 변경 사항
  - `UserNotFoundException`, `WatermarkNotFoundException` 적용
  - Base64 유효성/디코딩 실패 → `ImageDecodingException`
  - S3 업로드 실패 → `StorageException`
  - 외부 DTO(`WatermarkFlaskResponseDTO`) 유효성 검증 → `InvalidWatermarkResponseException`
  - 삭제 시 미존재 자원 처리: 조회 후 삭제(또는 `deleteBy...`가 `int` 반환하도록 수정 권장)
- 효과
  - 목록/단건/삭제 흐름에서 일관된 404/400/5xx 처리

## #️⃣ Issue number and link
#65 : 예외 처리 일원화
#34 #40 : 딥페이크 탐지 서비스 안정화
#44 #45 : 워터마크 서비스 안정화 

## 💬 Message to the Reviewer
- 컨트롤러에서의 예외 처리 코드는 제거(또는 최소화)했습니다. 
- `deleteBy...` 메서드가 `int`를 반환하도록 리포지토리 시그니처 변경을 고려하고 있습니다(0건 삭제 시 404 반환 용이)

