### PR TITLE
Feat: 워터마크 엔티티 fileName 추가 및 WebClient 버퍼 상향(256KB → 10MB)

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermark/WatermarkDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermark/WatermarkDTO.java
@@ -13,12 +13,14 @@ import java.time.LocalDateTime;
 public class WatermarkDTO {
     private Long id;
     private String watermarkedFilePath;
+    private String fileName;
     private LocalDateTime createdAt;
 
     public static WatermarkDTO fromEntity(Watermark entity){
         return WatermarkDTO.builder()
                 .id(entity.getWatermarkId())
                 .watermarkedFilePath(entity.getWatermarkedFilePath())
+                .fileName(entity.getFileName())
                 .createdAt(entity.getCreatedAt())
                 .build();
     }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebClientConfig.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebClientConfig.java
@@ -2,12 +2,19 @@ package com.deeptruth.deeptruth.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class WebClientConfig {
     @Bean
     public WebClient webClient() {
-        return WebClient.builder().build();
+        ExchangeStrategies strategies = ExchangeStrategies.builder()
+                .codecs(c -> c.defaultCodecs().maxInMemorySize(10 * 1024 * 1024)) // 10MB
+                .build();
+
+        return WebClient.builder()
+                .exchangeStrategies(strategies).
+                build();
     }
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/Watermark.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/Watermark.java
@@ -24,6 +24,9 @@ public class Watermark {
     @Column(nullable=false, length = 255)
     private String watermarkedFilePath;
 
+    @Column(nullable=false, length = 255)
+    private String fileName;
+
     @Column(nullable=false, updatable = false)
     private LocalDateTime createdAt;
 

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
@@ -34,6 +34,7 @@ public class WatermarkService {
         Watermark watermark = Watermark.builder()
                 .user(user)
                 .watermarkedFilePath(dto.getWatermarkedFilePath())
+                .fileName(dto.getFilename())
                 .createdAt(LocalDateTime.now())
                 .build();
 


### PR DESCRIPTION
## 📝 Summary
- 워터마크 엔티티에 fileName 컬럼을 추가하고, 관련 DTO를 수정했습니다. 
- 워터마크 삽입 처리 흐름을 안정화하고, Flask ↔ Spring 간 전송 시 발생하던 `DataBufferLimitException(256KB)` 문제를 해결했습니다.

## 💻 Describe your changes
1) 워터마크 삽입 처리 로직 수정
   - `WatermarkFlaskResponseDTO` 및 `WatermarkDTO`에 `filename` 필드 추가
   - S3 저장 시 사용된 파일명 그대로 반환 → 클라이언트 표시 가능

2) WebClient in‑memory 버퍼 한도 상향
   - 기본 256KB → **10MB**로 상향
   - 대용량 이미지 응답 처리 중 발생하던 `DataBufferLimitException` 해결
   - 
## #️⃣ Issue number and link
#58 #44 #45 

## 💬 Message to the Reviewer
- 장기적으로 base64 대신 스트리밍 업로드로 메모리 사용 최적화 가능
- 운영 환경에서 이미지 최대 크기 정책/압축 정책 협의 필요