### PR TITLE
Fix: Flask 응답 정규화 및 옵션 전달 개선

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/FlaskResponseDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/FlaskResponseDTO.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.Map;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -20,6 +22,12 @@ public class FlaskResponseDTO {
 
     @JsonProperty("most_suspect_image")
     private String base64Url;
+
+    @JsonProperty("options_used")
+    private Map<String, Object> optionsUsed;
+
+    @JsonProperty("taskId")
+    private String taskId;
 
     private String imageUrl;
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebClientConfig.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebClientConfig.java
@@ -1,19 +1,40 @@
 package com.deeptruth.deeptruth.config;
 
+import io.netty.channel.ChannelOption;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClient;import reactor.netty.http.client.HttpClient;
+
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class WebClientConfig {
     @Bean
     public WebClient webClient() {
+
+        HttpClient httpClient = HttpClient.create()
+                // 연결 타임아웃 (TCP connect)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10_000)       // 10초
+                // 서버 응답 헤더 받을 때까지의 타임아웃
+                .responseTimeout(Duration.ofSeconds(120))                   // 120초
+                // 데이터 송수신 타임아웃(스트림 단계)
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(120, TimeUnit.SECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler(120, TimeUnit.SECONDS))
+                );
+
         ExchangeStrategies strategies = ExchangeStrategies.builder()
                 .codecs(c -> c.defaultCodecs().maxInMemorySize(10 * 1024 * 1024)) // 10MB
                 .build();
 
         return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .exchangeStrategies(strategies).
                 build();
     }


### PR DESCRIPTION
## 📝 Summary
- Flask가 지원하는 **mode/options**(precision 전용 옵션 포함)를 multipart로 함께 전달하도록 개선했습니다.
- WebClientConfig에서 타임아웃 설정을 했습니다. 

## 💻 Describe your changes
1. **Controller**
   - `@RequestParam`으로 `mode`, `useTta`, `useIllum`, `detector`, `smoothWindow`, `minFace`, `sampleCount`를 수신.
   - `MultipartBodyBuilder`로 Flask에 추가 옵션을 **null-무시** 방식으로 전달.
   - Flask 응답의 확률 값을 **0–1 범위**로 안전 정규화(>1.0이면 `/100.0`)

2. **DTO (FlaskResponseDTO)**
   - Flask 응답에 맞게 DTO 필드 추가
   - `options_used`는 `Map<String, Object>`로 수신.

3. **WebClient 타임아웃 설정**
   - 장시간 분석 요청 대비 `ReactorClientHttpConnector` + `HttpClient`로 연결/응답/읽기/쓰기 타임아웃 지정.  

## #️⃣ Issue number and link
#40 

## 💬 Message to the Reviewer