### PR TITLE
Feat: 워터마크 삽입 로직 개편 및 Artifact/해시 기반 저장 구조 추가

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/Enum/MatchMethod.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/Enum/MatchMethod.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.Enum;
+
+public enum MatchMethod {
+    SHA256,
+    NORMALIZED_SHA256,
+    PHASH
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermark/InsertResultDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermark/InsertResultDTO.java
@@ -1,0 +1,12 @@
+package com.deeptruth.deeptruth.base.dto.watermark;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class InsertResultDTO {
+    private String artifactId;
+    private String watermarkedKey;
+    private String message;
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermark/WatermarkDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermark/WatermarkDTO.java
@@ -19,7 +19,6 @@ public class WatermarkDTO {
     public static WatermarkDTO fromEntity(Watermark entity){
         return WatermarkDTO.builder()
                 .id(entity.getWatermarkId())
-                .watermarkedFilePath(entity.getWatermarkedFilePath())
                 .fileName(entity.getFileName())
                 .createdAt(entity.getCreatedAt())
                 .build();

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/Watermark.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/Watermark.java
@@ -11,7 +11,17 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "watermark")
+@Table(name = "watermark",
+        indexes = {
+                @Index(name = "idx_wm_sha256", columnList = "sha256"),
+                @Index(name = "idx_wm_norm_sha256", columnList = "normalized_sha256"),
+                @Index(name = "idx_wm_phash", columnList = "phash"),
+                @Index(name = "idx_wm_user_created", columnList = "user_id, created_at")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_wm_artifact", columnNames = {"artifact_id"})
+        }
+)
 public class Watermark {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,8 +31,33 @@ public class Watermark {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(nullable=false, length = 255)
-    private String watermarkedFilePath;
+    /** 아티팩트 고유 식별자 (UUID 문자열) */
+    @Column(name = "artifact_id", nullable = false, length = 36, unique = true)
+    private String artifactId;
+
+    /** 삽입 메시지 (최대 4자) */
+    @Column(nullable = false, length = 4)
+    private String message;
+
+    /** 원본 바이트 기준 정확매칭용 */
+    @Column(nullable = false, length = 64)
+    private String sha256;
+
+    /** 정규화(무손실 PNG/EXIF적용) 후 SHA256 — 선택 */
+    @Column(name = "normalized_sha256", length = 64)
+    private String normalizedSha256;
+
+    /** pHash 64bit (근사매칭용) */
+    @Column(nullable = false)
+    private Long phash;
+
+    /** 결과물 S3 키(경로) */
+    @Column(name = "s3_watermarked_key", nullable = false, length = 255)
+    private String s3WatermarkedKey;
+
+    /** message.txt S3 키(경로) */
+    @Column(name = "s3_message_key", nullable = false, length = 255)
+    private String s3MessageKey;
 
     @Column(nullable=false, length = 255)
     private String fileName;

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/WatermarkDetection.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/WatermarkDetection.java
@@ -1,5 +1,6 @@
 package com.deeptruth.deeptruth.entity;
 
+import com.deeptruth.deeptruth.base.Enum.MatchMethod;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -11,28 +12,51 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "watermarkDetection")
+@Table(name = "watermarkDetection",
+        indexes = {
+                @Index(name = "idx_wmd_wm", columnList = "watermark_id"),
+                @Index(name = "idx_wmd_user_created", columnList = "user_id, detected_at")
+        }
+)
 public class WatermarkDetection {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long watermarkDetectionId;
 
-    @OneToOne
-    @JoinColumn(name = "watermark_id", unique = true, nullable = false)
+    @ManyToOne
+    @JoinColumn(name = "watermark_id")
     private Watermark watermark;
 
-    @ManyToOne
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(nullable=false, length = 255)
-    private String originalFilePath;
+    /** 업로드 이미지로 계산한 해시들 (로그/분석용) */
+    @Column(name = "uploaded_sha256", length = 64)
+    private String uploadedSha256;
 
-    @Column(nullable=false, length = 255)
-    private String resultFilePath;
+    @Column(name = "uploaded_normalized_sha256", length = 64)
+    private String uploadedNormalizedSha256;
 
-    @Column
-    private Float watermarkResult;
+    @Column(name = "uploaded_phash")
+    private Long uploadedPhash;
+
+    /** 매칭 방식: SHA256 / NORMALIZED_SHA256 / PHASH / NONE */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "match_method", length = 24, nullable = false)
+    private MatchMethod matchMethod;
+
+    /** pHash 근사매칭 시 해밍거리(정확/정규화 일치면 0 또는 null) */
+    @Column(name = "phash_distance")
+    private Integer phashDistance;
+
+    /** Flask가 리턴한 비트 정확도(%) */
+    @Column(name = "bit_accuracy")
+    private Float bitAccuracy;
+
+    /** 탐지 시점 */
+    @Column(name = "detected_at", nullable = false, updatable = false)
+    private LocalDateTime detectedAt;
 
     @Column(nullable=false, updatable = false)
     private LocalDateTime watermarkDetectedAt;

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
@@ -1,5 +1,6 @@
 package com.deeptruth.deeptruth.service;
 
+import com.deeptruth.deeptruth.base.dto.watermark.InsertResultDTO;
 import com.deeptruth.deeptruth.base.dto.watermark.WatermarkDTO;
 import com.deeptruth.deeptruth.base.dto.watermark.WatermarkFlaskResponseDTO;
 import com.deeptruth.deeptruth.base.exception.*;
@@ -7,14 +8,25 @@ import com.deeptruth.deeptruth.entity.User;
 import com.deeptruth.deeptruth.entity.Watermark;
 import com.deeptruth.deeptruth.repository.UserRepository;
 import com.deeptruth.deeptruth.repository.WatermarkRepository;
+import com.deeptruth.deeptruth.util.ImageHashUtils;
+import com.deeptruth.deeptruth.util.ImageNormalizer;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.List;
@@ -28,49 +40,98 @@ public class WatermarkService {
     private final WatermarkRepository watermarkRepository;
     private final UserRepository userRepository;
     private final AmazonS3Service amazonS3Service;
-      
-    public WatermarkDTO createWatermark(Long userId, WatermarkFlaskResponseDTO dto){
+    private final WebClient webClient;
+
+    @Value("${flask.watermarkServer.url}")
+    private String flaskServerUrl;
+
+    public InsertResultDTO insert(Long userId, MultipartFile file, String message) {
+        // 1) 유효성
+        if (message == null || message.length() > 4) {
+            throw new IllegalArgumentException("message는 최대 4자입니다.");
+        }
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(userId));
 
-        if (dto == null) {
-            throw new InvalidWatermarkResponseException("dto is null");
-        }
-        if (dto.getWatermarkedFilePath() == null || dto.getWatermarkedFilePath().isBlank()) {
-            throw new InvalidWatermarkResponseException("watermarkedFilePath is blank");
+        // 2) 원본 바이트 & 해시 계산
+        final byte[] original;
+        try {
+            original = file.getBytes();
+        } catch (IOException e) {
+            throw new RuntimeException("업로드 파일을 읽을 수 없습니다.", e);
         }
 
-        Watermark watermark = Watermark.builder()
+        String sha256 = ImageHashUtils.sha256(original);
+        long phash = ImageHashUtils.pHash(original);
+
+        byte[] normalized = ImageNormalizer.normalizeToPng(original); // EXIF/ICC 정규화 → PNG
+        String normalizedSha256 = ImageHashUtils.sha256(normalized);
+
+        // 3) Flask 호출 (image+message) → 워터마크 이미지(base64) 수신
+        ByteArrayResource imagePart = new ByteArrayResource(original) {
+            @Override public String getFilename() { return file.getOriginalFilename(); }
+        };
+        MultipartBodyBuilder builder = new MultipartBodyBuilder();
+        builder.part("image", imagePart);
+        builder.part("message", message);
+
+        WatermarkFlaskResponseDTO flask = webClient.post()
+                .uri(flaskServerUrl + "/watermark-insert")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(builder.build()))
+                .retrieve()
+                .bodyToMono(WatermarkFlaskResponseDTO.class)
+                .block();
+
+        if (flask == null || flask.getImage_base64() == null || flask.getImage_base64().isBlank()) {
+            throw new RuntimeException("Flask 서버 응답이 비어 있습니다.");
+        }
+
+        byte[] watermarkedBytes;
+        try {
+            watermarkedBytes = Base64.getDecoder().decode(flask.getImage_base64());
+        } catch (IllegalArgumentException e) {
+            throw new RuntimeException("Flask 응답의 base64 디코딩 실패", e);
+        }
+
+        // 4) S3 업로드 (artifactId 기준 경로)
+        String artifactId = UUID.randomUUID().toString();
+        String baseKey = "watermarks/%d/%s/".formatted(userId, artifactId);
+        String wmKey   = baseKey + "watermarked.png";
+        String msgKey  = baseKey + "message.txt";
+
+        try (InputStream wmIs = new ByteArrayInputStream(watermarkedBytes);
+             InputStream msgIs = new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8))) {
+
+            amazonS3Service.uploadStream(wmIs, wmKey, "image/png");
+            amazonS3Service.uploadStream(msgIs, msgKey, "text/plain");
+        } catch (Exception e) {
+            throw new StorageException("S3 업로드 실패", e);
+        }
+
+        // 5) DB 저장
+        Watermark wm = Watermark.builder()
                 .user(user)
-                .watermarkedFilePath(dto.getWatermarkedFilePath())
-                .fileName(dto.getFilename())
+                .artifactId(artifactId)
+                .message(message)
+                .sha256(sha256)
+                .normalizedSha256(normalizedSha256)
+                .phash(phash)
+                .s3WatermarkedKey(wmKey)
+                .s3MessageKey(msgKey)
+                .fileName(flask.getFilename())
                 .createdAt(LocalDateTime.now())
                 .build();
 
-        watermarkRepository.save(watermark);
-        return WatermarkDTO.fromEntity(watermark);
-    }
+        watermarkRepository.save(wm);
 
-    public String uploadBase64ImageToS3(String base64Image, Long userId) {
-        if (base64Image == null || base64Image.isBlank()) {
-            throw new ImageDecodingException("empty string");
+        // 6) 응답
+        return InsertResultDTO.builder()
+                .artifactId(artifactId)
+                .watermarkedKey(wmKey)
+                .message(message)
+                .build();
         }
-
-        final byte[] decodedBytes;
-        try {
-            decodedBytes = Base64.getDecoder().decode(base64Image);
-        } catch (IllegalArgumentException e) {
-            throw new ImageDecodingException("malformed base64");
-        }
-
-        try (InputStream inputStream = new ByteArrayInputStream(decodedBytes)) {
-            String key = "watermark/marked/" + userId + "/" + UUID.randomUUID() + ".jpg";
-            return amazonS3Service.uploadBase64Image(inputStream, key);
-        } catch (Exception e) {
-            // S3 업로드 실패 → 5xx
-            throw new StorageException("failed to upload image to S3", e);
-        }
-    }
   
     public Page<WatermarkDTO> getAllResult(Long userId, Pageable pageable){
         userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/util/ImageHashUtils.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/util/ImageHashUtils.java
@@ -1,0 +1,83 @@
+package com.deeptruth.deeptruth.util;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.util.Arrays;
+
+public class ImageHashUtils {
+
+    public static String sha256(byte[] data) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] dig = md.digest(data);
+            StringBuilder sb = new StringBuilder(64);
+            for (byte b : dig) sb.append(String.format("%02x", b));
+            return sb.toString();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // 간단 pHash (32x32 grayscale → DCT → 8x8 상위계수 median)
+    public static long pHash(byte[] data) {
+        try (InputStream is = new ByteArrayInputStream(data)) {
+            BufferedImage img = ImageIO.read(is);
+            if (img == null) throw new IllegalArgumentException("invalid image");
+
+            BufferedImage gray = new BufferedImage(32, 32, BufferedImage.TYPE_BYTE_GRAY);
+            Graphics2D g = gray.createGraphics();
+            g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+            g.drawImage(img, 0, 0, 32, 32, null);
+            g.dispose();
+
+            double[][] px = new double[32][32];
+            for (int y = 0; y < 32; y++)
+                for (int x = 0; x < 32; x++)
+                    px[y][x] = gray.getRaster().getSample(x, y, 0);
+
+            double[][] dct = dct2D(px);
+            double[] coeff = new double[64];
+            int k = 0;
+            for (int y = 0; y < 8; y++) {
+                for (int x = 0; x < 8; x++) {
+                    if (x == 0 && y == 0) continue; // DC 제외
+                    coeff[k++] = dct[y][x];
+                }
+            }
+            double median = median(coeff);
+            long hash = 0L;
+            for (int i = 0; i < 64; i++) if (coeff[i] >= median) hash |= (1L << (63 - i));
+            return hash;
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static double[][] dct2D(double[][] f) {
+        int N = 32;
+        double[][] F = new double[N][N];
+        double c0 = Math.sqrt(1.0 / N), c = Math.sqrt(2.0 / N);
+        for (int u = 0; u < N; u++) for (int v = 0; v < N; v++) {
+            double sum = 0.0;
+            for (int x = 0; x < N; x++) for (int y = 0; y < N; y++) {
+                sum += f[x][y] *
+                        Math.cos(((2 * x + 1) * u * Math.PI) / (2 * N)) *
+                        Math.cos(((2 * y + 1) * v * Math.PI) / (2 * N));
+            }
+            double au = (u == 0) ? c0 : c, av = (v == 0) ? c0 : c;
+            F[u][v] = au * av * sum;
+        }
+        return F;
+    }
+    private static double median(double[] a) {
+        double[] b = a.clone();
+        Arrays.sort(b);
+        int m = b.length / 2;
+        return (b.length % 2 == 0) ? (b[m - 1] + b[m]) / 2.0 : b[m];
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/util/ImageNormalizer.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/util/ImageNormalizer.java
@@ -1,0 +1,31 @@
+package com.deeptruth.deeptruth.util;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+public class ImageNormalizer {
+    public static byte[] normalizeToPng(byte[] input) {
+        try (InputStream is = new ByteArrayInputStream(input)) {
+            BufferedImage src = ImageIO.read(is);
+            if (src == null) throw new IllegalArgumentException("invalid image");
+
+            // (간단 버전) sRGB PNG로 덤프 + 메타 제거
+            BufferedImage rgb = new BufferedImage(
+                    src.getWidth(), src.getHeight(), BufferedImage.TYPE_INT_ARGB);
+            Graphics2D g = rgb.createGraphics();
+            g.drawImage(src, 0, 0, null);
+            g.dispose();
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            ImageIO.write(rgb, "png", out);
+            return out.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+


### PR DESCRIPTION
## 📝 Summary
워터마크 삽입 기능을 전면 개편하여 `artifactId` 기반 관리와 이미지 해시(SHA-256, normalized SHA-256, pHash) 저장 기능을 추가했습니다.  
S3 저장 구조를 표준화하고, Flask 응답 검증 및 업로드 로직을 개선했습니다.

## 💻 Describe your changes
- **Artifact 기반 저장 구조 도입**
  - `artifactId`(UUID) 생성하여 워터마크 결과물과 메시지를 고유 식별자로 묶음
  - DB에 `artifactId`와 해시값 컬럼 추가, 검색 인덱스 설정
- **해시값 저장**
  - 원본 이미지 SHA-256
  - EXIF 제거 후 normalized SHA-256
  - pHash(Perceptual Hash)
- **S3 저장 경로 변경**
  - `watermarks/{userId}/{artifactId}/watermarked.png`
  - `watermarks/{userId}/{artifactId}/message.txt`
- **Service 로직 개선**
  - 기존 단순 업로드 → Flask 호출 → 해시 계산 → S3 업로드 → DB 저장
  - Flask 응답 null/blank 처리 강화
- **AmazonS3Service 확장**
  - `uploadStream(InputStream, String, String)` 메서드 추가 (ContentType 지정 가능)
- **DTO 추가**
  - `InsertResultDTO` 생성 (artifactId, S3 key, message 포함)
  - `WatermarkFlaskResponseDTO`에 `filename` 필드 추가

## #️⃣ Issue number and link
#44 

## 💬 Message to the Reviewer
