### PR TITLE
Fix: 파일명 관리 개선 - 저장용과 표시용 분리

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/noise/NoiseDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/noise/NoiseDTO.java
@@ -11,6 +11,8 @@ import java.time.LocalDateTime;
 public class NoiseDTO {
     private Long noiseId;
     private Long userId;
+    private String fileName;
+    private String originalFileName;
     private String originalFilePath;
     private String processedFilePath;
     private Float epsilon;
@@ -30,6 +32,8 @@ public class NoiseDTO {
         return NoiseDTO.builder()
                 .noiseId(entity.getNoiseId())
                 .userId(entity.getUser().getUserId())
+                .fileName(entity.getFileName())
+                .originalFileName(entity.getOriginalFileName())
                 .originalFilePath(entity.getOriginalFilePath())
                 .processedFilePath(entity.getProcessedFilePath())
                 .epsilon(entity.getEpsilon())
@@ -45,6 +49,8 @@ public class NoiseDTO {
         return NoiseDTO.builder()
                 .noiseId(entity.getNoiseId())
                 .userId(entity.getUser().getUserId())
+                .fileName(entity.getFileName())
+                .originalFileName(entity.getOriginalFileName())
                 .originalFilePath(entity.getOriginalFilePath())
                 .processedFilePath(entity.getProcessedFilePath())
                 .epsilon(entity.getEpsilon())
@@ -67,4 +73,5 @@ public class NoiseDTO {
         }
         return null;
     }
+
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/NoiseController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/NoiseController.java
@@ -80,24 +80,20 @@ public class NoiseController {
             // S3 업로드
             if (flaskResult.getOriginalFilePath() != null &&
                     flaskResult.getOriginalFilePath().startsWith("data:image/")) {
-
                 String originalUrl = noiseService.uploadBase64ImageToS3(
-                        flaskResult.getOriginalFilePath(), user.getUserId(), "original");
+                        flaskResult.getOriginalFilePath(), user.getUserId(), "original", multipartFile.getOriginalFilename());
                 flaskResult.setOriginalFilePath(originalUrl);
             }
-
             if (flaskResult.getProcessedFilePath() != null &&
                     flaskResult.getProcessedFilePath().startsWith("data:image/")) {
-
                 String processedUrl = noiseService.uploadBase64ImageToS3(
-                        flaskResult.getProcessedFilePath(), user.getUserId(), "processed");
+                        flaskResult.getProcessedFilePath(), user.getUserId(), "processed", multipartFile.getOriginalFilename());
                 flaskResult.setProcessedFilePath(processedUrl);
             }
-
             // Service 호출
-            NoiseDTO createdNoise = noiseService.createNoise(user.getUserId(), flaskResult);
+            NoiseDTO createdNoise = noiseService.createNoise(user.getUserId(), flaskResult, multipartFile.getOriginalFilename());;
 
-            return ResponseEntity.ok(ResponseDTO.success(200, "적대적 노이즈 생성 성공", createdNoise));
+            return ResponseEntity.ok(ResponseDTO.success(200, "적대적 노이즈 삽입 성공", createdNoise));
 
         } catch (Exception e) {
             log.error("❌ 적대적 노이즈 생성 중 오류 발생: ", e);

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/Noise.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/Noise.java
@@ -21,6 +21,12 @@ public class Noise {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Column
+    private String originalFileName;  // 원본 파일명
+
+    @Column
+    private String fileName;          // 저장용 파일명
+
     @Column(nullable=false, length = 255)
     private String originalFilePath;
 


### PR DESCRIPTION
## 📝 Summary
> 적대적 노이즈 파일명 관리 체계를 개선했습니다. 저장용 파일명(UUID)과 사용자 저장용 표시명(fileName)을 분리하고, 원본 파일명(originalFileName)도 별도로 관리하도록 구조를 리팩터링했습니다.

## 💻 Describe your changes
- S3에는 기존대로 UUID 기반의 저장용 파일명을 사용해 충돌 방지
- DB 및 API 응답에는 사용자 친화적 파일명(fileName)과 원본 파일명(originalFileName) 모두 포함
- Noise 엔티티에 두 파일명 필드(originalFileName, fileName) 추가 및 역할 분리
<img width="220" height="121" alt="image" src="https://github.com/user-attachments/assets/f1f8e3ef-c248-418f-a4fa-fe8086c2d355" />
- 서비스/컨트롤러에서 S3 업로드 시 originalFileName 파라미터 전달하도록 변경
- generateFileName 메서드로 사용자 친화적 파일명 생성 정책 구현
- NoiseDTO/NoiseFlaskResponseDTO 등 DTO 매핑 및 필드 정리
- 메서드/필드 네이밍 및 역할 일치화

## #️⃣ Issue number and link
> #82 

## 💬 Message to the Reviewer

