### PR TITLE
Fix: Deepfake 응답에 정밀모드 옵션 추가

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/Enum/DeepfakeDetector.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/Enum/DeepfakeDetector.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.Enum;
+
+public enum DeepfakeDetector {
+    AUTO,
+    DLIB,
+    DNN
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/Enum/DeepfakeMode.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/Enum/DeepfakeMode.java
@@ -1,0 +1,6 @@
+package com.deeptruth.deeptruth.base.Enum;
+
+public enum DeepfakeMode {
+    DEFAULT,
+    PRECISION
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/DeepfakeDetectionDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/DeepfakeDetectionDTO.java
@@ -1,7 +1,12 @@
 package com.deeptruth.deeptruth.base.dto.deepfake;
 
+import com.deeptruth.deeptruth.base.Enum.DeepfakeDetector;
+import com.deeptruth.deeptruth.base.Enum.DeepfakeMode;
 import com.deeptruth.deeptruth.base.Enum.DeepfakeResult;
 import com.deeptruth.deeptruth.entity.DeepfakeDetection;
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,6 +21,13 @@ public class DeepfakeDetectionDTO {
     private Float averageConfidence;
     private Float maxConfidence;
     private LocalDateTime createdAt;
+    private DeepfakeMode mode;
+    private Boolean useTta;
+    private Boolean useIllum;
+    private DeepfakeDetector detector;
+    private Integer smoothWindow;
+    private Integer minFace;
+    private Integer sampleCount;
 
     public static DeepfakeDetectionDTO fromEntity(DeepfakeDetection entity) {
         return DeepfakeDetectionDTO.builder()
@@ -25,6 +37,13 @@ public class DeepfakeDetectionDTO {
                 .averageConfidence(entity.getAverageConfidence())
                 .maxConfidence(entity.getMaxConfidence())
                 .createdAt(entity.getCreatedAt())
+                .mode(entity.getMode())
+                .useTta(entity.getUseTta())
+                .useIllum(entity.getUseIllum())
+                .detector(entity.getDetector())
+                .smoothWindow(entity.getSmoothWindow())
+                .minFace(entity.getMinFace())
+                .sampleCount(entity.getSampleCount())
                 .build();
     }
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/FlaskResponseDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/FlaskResponseDTO.java
@@ -23,8 +23,24 @@ public class FlaskResponseDTO {
     @JsonProperty("most_suspect_image")
     private String base64Url;
 
-    @JsonProperty("options_used")
-    private Map<String, Object> optionsUsed;
+    private String detector;
+
+    @JsonProperty("min_face")
+    private Integer minFace;
+
+    private String mode;
+
+    @JsonProperty("sample_count")
+    private Integer sampleCount;
+
+    @JsonProperty("smooth_window")
+    private Integer smoothWindow;
+
+    @JsonProperty("use_illum")
+    private Boolean useIllum;
+
+    @JsonProperty("use_tta")
+    private Boolean useTta;
 
     @JsonProperty("taskId")
     private String taskId;

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/DeepfakeDetection.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/DeepfakeDetection.java
@@ -1,5 +1,7 @@
 package com.deeptruth.deeptruth.entity;
 
+import com.deeptruth.deeptruth.base.Enum.DeepfakeDetector;
+import com.deeptruth.deeptruth.base.Enum.DeepfakeMode;
 import com.deeptruth.deeptruth.base.Enum.DeepfakeResult;
 import jakarta.persistence.*;
 import lombok.*;
@@ -31,11 +33,35 @@ public class DeepfakeDetection {
 
     @Column
     private Float averageConfidence;
+
     @Column
     private Float maxConfidence;
 
     @Column(nullable=false, updatable = false)
     private LocalDateTime createdAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private DeepfakeMode mode;
+
+    @Column
+    private Boolean useTta;
+
+    @Column
+    private Boolean useIllum;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private DeepfakeDetector detector;
+
+    @Column
+    private Integer smoothWindow;
+
+    @Column
+    private Integer minFace;
+
+    @Column
+    private Integer sampleCount;
 
     @PrePersist
     protected void onCreate() {

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
@@ -1,5 +1,7 @@
 package com.deeptruth.deeptruth.service;
 
+import com.deeptruth.deeptruth.base.Enum.DeepfakeDetector;
+import com.deeptruth.deeptruth.base.Enum.DeepfakeMode;
 import com.deeptruth.deeptruth.base.Enum.DeepfakeResult;
 import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionDTO;
 import com.deeptruth.deeptruth.base.dto.deepfake.FlaskResponseDTO;
@@ -57,6 +59,13 @@ public class DeepfakeDetectionService {
                 .result(dto.getResult())
                 .averageConfidence(dto.getAverageConfidence())
                 .maxConfidence(dto.getMaxConfidence())
+                .mode(DeepfakeMode.valueOf(dto.getMode().toUpperCase()))
+                .useTta(dto.getUseTta())
+                .useIllum(dto.getUseIllum())
+                .detector(DeepfakeDetector.valueOf(dto.getDetector().toUpperCase()))
+                .smoothWindow(dto.getSmoothWindow())
+                .minFace(dto.getMinFace())
+                .sampleCount(dto.getSampleCount())
                 .build();
 
         deepfakeDetectionRepository.save(detection);


### PR DESCRIPTION
## 📝 Summary
- Deepfake 응답에 정밀 모드 옵션 7개를 추가했습니다. 

## 💻 Describe your changes
- DeepfakeDetection 엔티티에 탐지 모드(DetectionMode), 탐지기 종류 등 옵션 7개 필드 추가
- FlaskResponseDTO → DeepfakeDetection 변환 시 문자열 → Enum 매핑 로직 적용
- DB에는 EnumType.STRING 방식으로 저장되어 "DEFAULT", "PRECISION", "AUTO", "DLIB", "DNN" 등 명확한 값이 남도록 개선

## #️⃣ Issue number and link
#40 

## 💬 Message to the Reviewer