### PR TITLE
Feat: 적대적 노이즈 자동/정밀 모드 mode, level 필드 연동 및 히스토리 API 반영

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/noise/NoiseDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/noise/NoiseDTO.java
@@ -19,6 +19,9 @@ public class NoiseDTO {
     private Boolean attackSuccess;
     private String originalPrediction;
     private String adversarialPrediction;
+    private String mode;                 // "auto" 또는 "precision"
+    private Integer level;               // 1-4 (정밀 모드만)
+    private String modeDescription;      // "자동 모드" 또는 "정밀 모드"
     private LocalDateTime createdAt;
 
     // 프론트 표시용
@@ -43,6 +46,9 @@ public class NoiseDTO {
                 .adversarialPrediction(entity.getAdversarialPrediction())
                 .originalConfidence(entity.getOriginalConfidence())
                 .adversarialConfidence(entity.getAdversarialConfidence())
+                .mode(entity.getMode())
+                .level(entity.getLevel())
+                .modeDescription(getModeDescription(entity.getMode(), entity.getLevel()))
                 .build();
     }
 
@@ -66,6 +72,9 @@ public class NoiseDTO {
                 .originalConfidence(flaskResponse.getOriginalConfidence())
                 .adversarialConfidence(flaskResponse.getAdversarialConfidence())
                 .confidenceDrop(flaskResponse.getConfidenceDrop())
+                .mode(flaskResponse.getMode())
+                .level(flaskResponse.getLevel())
+                .modeDescription(getModeDescription(flaskResponse.getMode(), flaskResponse.getLevel()))
                 .build();
     }
 
@@ -74,6 +83,25 @@ public class NoiseDTO {
             return originalPrediction + " → " + adversarialPrediction;
         }
         return null;
+    }
+
+    // 모드 설명 생성 헬퍼 메서드 추가
+    private static String getModeDescription(String mode, Integer level) {
+        if ("precision".equals(mode) && level != null) {
+            switch (level) {
+                case 1:
+                    return "정밀 모드 (약함)";
+                case 2:
+                    return "정밀 모드 (보통)";
+                case 3:
+                    return "정밀 모드 (강함)";
+                case 4:
+                    return "정밀 모드 (매우 강함)";
+                default:
+                    return "정밀 모드";
+            }
+        }
+        return "자동 모드";
     }
 
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/noise/NoiseFlaskResponseDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/noise/NoiseFlaskResponseDTO.java
@@ -39,5 +39,11 @@ public class NoiseFlaskResponseDTO {
     @JsonProperty("confidenceDrop")
     private String confidenceDrop;
 
+    @JsonProperty("mode")
+    private String mode;              // "auto" or "precision"
+
+    @JsonProperty("level")
+    private Integer level;            // 1-4 (precision 모드만)
+
     private String message;
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/Noise.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/Noise.java
@@ -45,12 +45,21 @@ public class Noise {
     @Column
     private String adversarialPrediction; // 적대적 노이즈 적용 후 이미지 예측
 
+    // 상세 통계 필드 추가
+    @Column
+    private String originalConfidence;     // 신뢰도 변화용
+
+    @Column
+    private String adversarialConfidence;  // 신뢰도 변화용
+
+    @Column(length = 20)
+    private String mode;              // "auto" or "precision"
+
+    @Column
+    private Integer level;            // 1-4, null for auto mode
+
     @Column(nullable=false, updatable = false)
     private LocalDateTime createdAt;
-
-    // 상세 통계 필드 추가
-    @Column private String originalConfidence;     // 신뢰도 변화용
-    @Column private String adversarialConfidence;  // 신뢰도 변화용
 
 
     @PrePersist

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/NoiseService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/NoiseService.java
@@ -65,6 +65,8 @@ public class NoiseService {
                 .adversarialPrediction(dto.getAdversarialPrediction())
                 .originalConfidence(dto.getOriginalConfidence())
                 .adversarialConfidence(dto.getAdversarialConfidence())
+                .mode(dto.getMode())
+                .level(dto.getLevel())
                 .build();
 
         noiseRepository.save(noise);


### PR DESCRIPTION
## 📝 Summary
> 적대적 노이즈 자동/정밀 모드 mode, level 필드 연동 및 Spring Boot 백엔드 구현 완성

## 💻 Describe your changes
### Backend Changes
- **NoiseController**: Flask API 호출 시 mode, level 파라미터 전달 로직 추가
- **NoiseFlaskResponseDTO**: mode, level 필드 추가 및 JsonProperty 매핑
- **Noise Entity**: mode(String), level(Integer) 컬럼 추가
- **NoiseService**: Flask 응답 데이터의 mode, level을 DB에 저장하도록 구현
- **NoiseDTO**: mode, level, modeDescription 필드 추가 및 변환 메서드 수정
- **파라미터 검증**: 잘못된 mode, level 값에 대한 400 에러 처리 추가

## #️⃣ Issue number and link
> #86

## 💬 Message to the Reviewer
### 🎨 프론트엔드팀 연동 가이드 (@kangsujung )
#### 📡 API 변경사항
**1. 요청 (POST /api/noise):**
- `file`: MultipartFile (이미지 파일) - **필수**
- `mode`: "auto" | "precision" (기본값: "auto") - **선택**
- `level`: 1 | 2 | 3 | 4 (정밀 모드에서만 사용, 기본값: 2) - **선택**

**요청 예시:**
```
formData.append('file', 이미지파일);            // 필수
formData.append('mode', 'precision');         // 자동/정밀
formData.append('level', '3');                // 정밀 모드 시 단계
```

**2. 응답 데이터 구조**
- mode: "auto" 또는 "precision" // 사용된 모드
- level: 1~4 (정밀 모드만 값 존재, 자동이면 null)
- modeDescription: "정밀 3단계", "자동 모드" 등
- epsilon: 실사용 노이즈 강도 값
- attackSuccess: true/false (성공/실패)
- originalPrediction: 원본 이미지 분류 결과
- adversarialPrediction: 노이즈 적용 후 분류 결과
- originalConfidence, adversarialConfidence, confidenceDrop: 신뢰도 관련 값

**응답 예시**
```
{
  "data": {
    "noiseId": 123,
    "mode": "precision",
    "level": 3,
    "modeDescription": "정밀 모드 (강함)",
    "epsilon": 0.0375,
    "attackSuccess": true,
    "originalPrediction": "Art Nouveau (Modern)",
    "adversarialPrediction": "Surrealism",
    "originalConfidence": "0.233",
    "adversarialConfidence": "0.326",
    "confidenceDrop": "-9.3%",
    "createdAt": "2025-08-21T09:15:00"
  }
}
```


#### 신규 UI 컴포넌트 필요
1. **모드 선택 (라디오 버튼)**:
   -  자동 모드: `mode="auto"`
   -  정밀 모드: `mode="precision"`

2. **강도 단계 선택 (정밀 모드 선택 시 활성화)**:
   - 1단계 (약함): `level=1` (ε=0.015)
   - 2단계 (보통): `level=2` (ε=0.0225) - 기본값
   - 3단계 (강함): `level=3` (ε=0.0375)  
   - 4단계 (매우 강함): `level=4` (ε=0.06)

#### 상세 통계 섹션 수정
API 응답에서 다음 필드들을 사용하여 기존 4개 항목 교체:

1. **결과**: 
   - `attackSuccess: true` → "성공"
   - `attackSuccess: false` → "실패"

2. **분류 변화**: 
   - `originalPrediction !== adversarialPrediction` → "원본분류 → 변경분류"
   - `originalPrediction === adversarialPrediction` → "분류명 (변화 없음)"

3. **신뢰도 변화**: 
   - `attackSuccess: true` → "-"
   - `attackSuccess: false` → `confidenceDrop` 값 표시 (예: "-9.3%")

4. **적대적 노이즈 강도**: 
   - `mode: "auto"` → "자동 모드 (ε=${epsilon})"
   - `mode: "precision"` → "정밀 ${level}단계 (ε=${epsilon})"
   - 또는 `modeDescription` 필드 직접 사용 가능
