### PR TITLE
Feat: 워터마크 기능에 대한 taskId 전달 플로우 추가 

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/WatermarkController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/WatermarkController.java
@@ -37,14 +37,14 @@ public class WatermarkController {
     private final WebClient webClient;
 
     @PostMapping
-    public ResponseEntity<ResponseDTO> insertWatermark(@AuthenticationPrincipal User user, @RequestPart("file") MultipartFile multipartFile, @RequestPart String message){
+    public ResponseEntity<ResponseDTO> insertWatermark(@AuthenticationPrincipal User user, @RequestPart("file") MultipartFile multipartFile, @RequestPart String message, @RequestParam(required = false) String taskId){
         try {
             if (user == null) {
                 return ResponseEntity.status(401)
                         .body(ResponseDTO.fail(401, "인증이 필요합니다."));
             }
 
-            InsertResultDTO result = waterMarkService.insert(user.getUserId(), multipartFile, message);
+            InsertResultDTO result = waterMarkService.insert(user.getUserId(), multipartFile, message, taskId);
             return ResponseEntity.ok(ResponseDTO.success(200, "워터마크 삽입 성공", result));
 
         } catch (IllegalArgumentException e) {

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/WatermarkDetectionController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/WatermarkDetectionController.java
@@ -8,10 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -23,13 +20,14 @@ public class WatermarkDetectionController {
     @PostMapping(value = "/detection", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ResponseDTO> detect(
             @AuthenticationPrincipal User user,
-            @RequestPart("file") MultipartFile file) {
+            @RequestPart("file") MultipartFile file,
+            @RequestParam(required = false) String taskId) {
         if (user == null) {
             return ResponseEntity.status(401)
                     .body(ResponseDTO.fail(401, "인증이 필요합니다."));
         }
         try {
-            DetectResultDTO result = detectionService.detect(user.getUserId(), file);
+            DetectResultDTO result = detectionService.detect(user.getUserId(), file, taskId);
             return ResponseEntity.ok(ResponseDTO.success(200, "워터마크 탐지 성공", result));
         } catch (IllegalStateException ex) {
             return ResponseEntity.status(404)

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkDetectionService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkDetectionService.java
@@ -36,7 +36,7 @@ public class WatermarkDetectionService {
     private static final int PHASH_THRESHOLD = 10;
 
 
-    public DetectResultDTO detect(Long userId, MultipartFile file) {
+    public DetectResultDTO detect(Long userId, MultipartFile file, String taskId) {
         final byte[] uploaded;
         try {
             uploaded = file.getBytes();
@@ -92,6 +92,7 @@ public class WatermarkDetectionService {
         MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
         form.add("image", imagePart);
         form.add("message", message);
+        form.add("taskId", taskId);
 
         WatermarkDetectionFlaskResponseDTO flask = webClient.post()
                 .uri(flaskBaseUrl + "/watermark-detection")

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
@@ -45,10 +45,13 @@ public class WatermarkService {
     @Value("${flask.watermarkServer.url}")
     private String flaskServerUrl;
 
-    public InsertResultDTO insert(Long userId, MultipartFile file, String message) {
+    public InsertResultDTO insert(Long userId, MultipartFile file, String message, String taskId) {
         // 1) 유효성
         if (message == null || message.length() > 4) {
             throw new IllegalArgumentException("message는 최대 4자입니다.");
+        }
+        if (taskId == null || taskId.isBlank()) {
+            taskId = java.util.UUID.randomUUID().toString();
         }
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(userId));
@@ -74,6 +77,7 @@ public class WatermarkService {
         MultipartBodyBuilder builder = new MultipartBodyBuilder();
         builder.part("image", imagePart);
         builder.part("message", message);
+        builder.part("taskId", taskId);
 
         WatermarkFlaskResponseDTO flask = webClient.post()
                 .uri(flaskServerUrl + "/watermark-insert")


### PR DESCRIPTION
## 📝 Summary
워터마크 삽입/탐지 기능에 WebSocket 기반 진행률 전송 기능 추가했습니다. Flask 서버에서 전송한 진행률 데이터를 Spring이 수신하고, 구독 중인 클라이언트에게 실시간 브로드캐스트합니다.

## 💻 Describe your changes
삽입과 탐지에 `@RequestParam(required = false) String taskId`로 taskId를 받아와 진행률을 프론트로 브로드 캐스트합니다. 

## #️⃣ Issue number and link
#44 

## 💬 Message to the Reviewer