### PR TITLE
Refactor: 진행률 전송을 위한 taskId 추가 및 WebClientConfig 타임 아웃 증가

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/DeepfakeDetectionDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/DeepfakeDetectionDTO.java
@@ -28,6 +28,7 @@ public class DeepfakeDetectionDTO {
     private Integer smoothWindow;
     private Integer minFace;
     private Integer sampleCount;
+    private String taskId;
 
     public static DeepfakeDetectionDTO fromEntity(DeepfakeDetection entity) {
         return DeepfakeDetectionDTO.builder()
@@ -44,6 +45,7 @@ public class DeepfakeDetectionDTO {
                 .smoothWindow(entity.getSmoothWindow())
                 .minFace(entity.getMinFace())
                 .sampleCount(entity.getSampleCount())
+                .taskId(entity.getTaskId())
                 .build();
     }
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermark/InsertResultDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermark/InsertResultDTO.java
@@ -18,6 +18,7 @@ public class InsertResultDTO {
     private String normalizedSha256;
     private Long phash;
     private LocalDateTime createdAt;
+    private String taskId;
 
     public static InsertResultDTO fromEntity(Watermark entity){
         return InsertResultDTO.builder()
@@ -30,6 +31,7 @@ public class InsertResultDTO {
                 .normalizedSha256(entity.getNormalizedSha256())
                 .phash(entity.getPhash())
                 .createdAt(entity.getCreatedAt())
+                .taskId(entity.getTaskId())
                 .build();
     }
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermark/WatermarkDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermark/WatermarkDTO.java
@@ -15,12 +15,14 @@ public class WatermarkDTO {
     private String watermarkedFilePath;
     private String fileName;
     private LocalDateTime createdAt;
+    private String taskId;
 
     public static WatermarkDTO fromEntity(Watermark entity){
         return WatermarkDTO.builder()
                 .id(entity.getWatermarkId())
                 .fileName(entity.getFileName())
                 .createdAt(entity.getCreatedAt())
+                .taskId(entity.getTaskId())
                 .build();
     }
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermarkDetection/DetectResultDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/watermarkDetection/DetectResultDTO.java
@@ -15,4 +15,5 @@ public class DetectResultDTO {
     private String detectedAt;
     private String uploadedImageBase64; // 임계 미달 시만
     private String basename;
+    private String taskId;
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebClientConfig.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebClientConfig.java
@@ -22,11 +22,11 @@ public class WebClientConfig {
                 // 연결 타임아웃 (TCP connect)
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10_000)       // 10초
                 // 서버 응답 헤더 받을 때까지의 타임아웃
-                .responseTimeout(Duration.ofSeconds(120))                   // 120초
+                .responseTimeout(Duration.ofMinutes(5))                   // 120초
                 // 데이터 송수신 타임아웃(스트림 단계)
                 .doOnConnected(conn -> conn
-                        .addHandlerLast(new ReadTimeoutHandler(120, TimeUnit.SECONDS))
-                        .addHandlerLast(new WriteTimeoutHandler(120, TimeUnit.SECONDS))
+                        .addHandlerLast(new ReadTimeoutHandler(300, TimeUnit.SECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler(300, TimeUnit.SECONDS))
                 );
 
         ExchangeStrategies strategies = ExchangeStrategies.builder()

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/DeepfakeDetection.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/DeepfakeDetection.java
@@ -63,6 +63,9 @@ public class DeepfakeDetection {
     @Column
     private Integer sampleCount;
 
+    @Column
+    private String taskId;
+
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/Watermark.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/Watermark.java
@@ -65,6 +65,9 @@ public class Watermark {
     @Column(nullable=false, updatable = false)
     private LocalDateTime createdAt;
 
+    @Column
+    private String taskId;
+
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/WatermarkDetection.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/WatermarkDetection.java
@@ -61,6 +61,9 @@ public class WatermarkDetection {
     @Column(nullable=false, updatable = false)
     private LocalDateTime watermarkDetectedAt;
 
+    @Column
+    private String taskId;
+
     @PrePersist
     protected void onCreate() {
         this.watermarkDetectedAt = LocalDateTime.now();

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
@@ -66,6 +66,7 @@ public class DeepfakeDetectionService {
                 .smoothWindow(dto.getSmoothWindow())
                 .minFace(dto.getMinFace())
                 .sampleCount(dto.getSampleCount())
+                .taskId(dto.getTaskId())
                 .build();
 
         deepfakeDetectionRepository.save(detection);

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkDetectionService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkDetectionService.java
@@ -123,6 +123,7 @@ public class WatermarkDetectionService {
                 .detectedAt(flask.getDetected_at())
                 .uploadedImageBase64(flask.getImage_base64()) // 임계 미달 시에만 세팅됨
                 .basename(flask.getBasename())
+                .taskId(taskId)
                 .build();
     }
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
@@ -128,6 +128,7 @@ public class WatermarkService {
                 .s3MessageKey(msgUrl)
                 .fileName(flask.getFilename())
                 .createdAt(LocalDateTime.now())
+                .taskId(taskId)
                 .build();
 
         watermarkRepository.save(wm);
@@ -142,6 +143,7 @@ public class WatermarkService {
                 .normalizedSha256(normalizedSha256)
                 .phash(phash)
                 .createdAt(LocalDateTime.now())
+                .taskId(taskId)
                 .build();
         }
   


### PR DESCRIPTION
## 📝 Summary
- 진행률 연동 강화: 프론트에서 진행률 페이지 다음, 결과 페이지 연동을 위해 Deepfake/Watermark 엔티티 및 DTO에 `taskId` 필드 추가
- WebClient 타임아웃 확장: Flask `/predict` 장기 처리(수십 초~수분)에 대응하도록 connect/response/read/write 타임아웃을 대폭 상향.

## 💻 Describe your changes
### 1) Domain: 엔티티 및 관련 DTO에 taskId 추가
DeepfakeDetection
@Column private String taskId;
Watermark (동일 패턴)
@Column private String taskId;
WatermarkDetection (동일 패턴)
@Column private String taskId;

인덱스 추가

### 2) WebClientConfig
- Flask 호출 전용 WebClient에 긴 타임아웃(5분) 적용.


## #️⃣ Issue number and link
#40 #44 

## 💬 Message to the Reviewer
NOT NULL/UNIQUE는 적용하지 않았습니다. 재시도/중복 실행 가능성을 고려하여 운영 데이터 안정화 후 Unique 전환 검토 예정입니다. 