### PR TITLE
Feat: 회원 정보 수정 및 탈퇴 API 구현

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/user/UserProfile.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/user/UserProfile.java
@@ -1,10 +1,14 @@
 package com.deeptruth.deeptruth.base.dto.user;
 
+import com.deeptruth.deeptruth.base.Enum.Level;
 import com.deeptruth.deeptruth.base.Enum.Role;
+import com.deeptruth.deeptruth.base.Enum.SocialLoginType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 
 @Getter
 @Builder
@@ -17,4 +21,11 @@ public class UserProfile {
     private String nickname;
     private String email;
     private Role role;
+    private Level level;           // 사용자 레벨
+    private int point;             // 포인트
+    private String signature;      // 서명
+
+    // 계정 정보
+    private SocialLoginType socialLoginType;  // 소셜로그인 타입
+    private LocalDate createdAt;              // 가입일
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/user/UserUpdateRequest.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/user/UserUpdateRequest.java
@@ -1,0 +1,24 @@
+package com.deeptruth.deeptruth.base.dto.user;
+
+import jakarta.validation.constraints.Email;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserUpdateRequest {
+    // 일반+소셜
+    private String nickname;
+
+    // 일반
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    private String currentPassword;
+    private String newPassword;
+    private String newPasswordConfirm;
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/DuplicateEmailException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/DuplicateEmailException.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class DuplicateEmailException extends RuntimeException {
+  public DuplicateEmailException(String message) {
+    super(message);
+  }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/DuplicateNicknameException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/DuplicateNicknameException.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class DuplicateNicknameException extends RuntimeException {
+    public DuplicateNicknameException(String message) {
+        super(message);
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/GlobalExceptionHandler.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/GlobalExceptionHandler.java
@@ -10,22 +10,54 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    // 404 - 리소스 없음
-    @ExceptionHandler({UserNotFoundException.class, DetectionNotFoundException.class,  WatermarkNotFoundException.class})
-    public ResponseEntity<ResponseDTO> handleNotFound(RuntimeException ex) {
-        log.info("[404] {}", ex.getMessage());
-        return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(ResponseDTO.fail(404, ex.getMessage()));
-    }
-
     // 400 - 잘못된 요청
-    @ExceptionHandler({InvalidFileException.class, ImageDecodingException.class})
+    @ExceptionHandler({InvalidFileException.class, ImageDecodingException.class,
+            IllegalArgumentException.class})
     public ResponseEntity<ResponseDTO> handleBadRequest(RuntimeException ex) {
         log.info("[400] {}", ex.getMessage());
         return ResponseEntity
                 .badRequest()
                 .body(ResponseDTO.fail(400, ex.getMessage()));
+    }
+
+    // 401 - 인증 실패
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ResponseDTO> handleUserNotFoundException(RuntimeException ex) {
+        log.info("[401] {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ResponseDTO.fail(401, "존재하지 않는 회원입니다."));
+    }
+
+    @ExceptionHandler({InvalidPasswordException.class})
+    public ResponseEntity<ResponseDTO> handleInvalidPassword(RuntimeException ex) {
+        log.info("[401] {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ResponseDTO.fail(401, ex.getMessage()));
+    }
+
+    // 403 - 권한 부족
+    @ExceptionHandler({UnauthorizedOperationException.class})
+    public ResponseEntity<ResponseDTO> handleAuthorizationFailure(RuntimeException ex) {
+        log.info("[403] Authorization failed: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(ResponseDTO.fail(403, ex.getMessage()));
+    }
+
+    // 404 - 리소스 없음
+    @ExceptionHandler({DetectionNotFoundException.class, WatermarkNotFoundException.class, NoiseNotFoundException.class})
+    public ResponseEntity<ResponseDTO> handleResourceNotFound(RuntimeException ex) {
+        log.info("[404] {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ResponseDTO.fail(404, ex.getMessage()));
+    }
+
+    // 409 - 중복 리소스
+    @ExceptionHandler({DuplicateEmailException.class, DuplicateNicknameException.class})
+    public ResponseEntity<ResponseDTO> handleDuplicateResource(RuntimeException ex) {
+        log.info("[409] {}", ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(ResponseDTO.fail(409, ex.getMessage()));
     }
 
     // 422 - 처리할 수 없는 엔티티 (유효성은 맞지만 비즈니스 규칙 위반)
@@ -46,7 +78,7 @@ public class GlobalExceptionHandler {
                 .body(ResponseDTO.fail(502, ex.getMessage()));
     }
 
-    // 그 외 모든 예외 - 500
+    // 500 - 그 외 모든 예외
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ResponseDTO> handleGeneral(Exception ex) {
         log.error("[500] {}", ex.getMessage(), ex);
@@ -56,4 +88,5 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ResponseDTO.fail(500, "서버 내부 오류가 발생했습니다."));
     }
+
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/InvalidPasswordException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/InvalidPasswordException.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class InvalidPasswordException extends RuntimeException {
+    public InvalidPasswordException(String message) {
+        super(message);
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/UnauthorizedOperationException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/UnauthorizedOperationException.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class UnauthorizedOperationException extends RuntimeException {
+    public UnauthorizedOperationException(String message) {
+        super(message);
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/CustomUserDetails.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/CustomUserDetails.java
@@ -1,0 +1,63 @@
+package com.deeptruth.deeptruth.config;
+
+import com.deeptruth.deeptruth.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    public Long getUserId() {
+        return user.getUserId();
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(
+                new SimpleGrantedAuthority("ROLE_" + user.getRole().name())
+        );
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getLoginId();  // loginId가 username
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/SecurityConfig.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.deeptruth.deeptruth.config;
 
 import com.deeptruth.deeptruth.service.CustomOAuth2UserService;
+import com.deeptruth.deeptruth.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,12 +18,14 @@ public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
-    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler; // ✅ 주입
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final CustomUserDetailsService customUserDetailsService;
 
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .userDetailsService(customUserDetailsService)
                 // 세션 정책: OAuth2는 세션 사용, JWT API는 Stateless
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
@@ -35,7 +38,9 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/**"  // ⚡ 모든 요청을 인증 없이 허용 (임시 설정)
                         ).permitAll()
-                        .requestMatchers("/api/noise/**").authenticated()
+                        .requestMatchers("/api/noise/**",
+                                            "/api/users/**"
+                        ).authenticated()
                         .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/constants/LoginConstants.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/constants/LoginConstants.java
@@ -4,7 +4,7 @@ public class LoginConstants {
     // 에러 메시지
     public static final String EMPTY_LOGIN_ID_MESSAGE = "아이디를 입력해주세요.";
     public static final String EMPTY_PASSWORD_MESSAGE = "비밀번호를 입력해주세요.";
-    public static final String USER_NOT_FOUND_MESSAGE = "존재하지 않는 아이디입니다.";
+    public static final String USER_NOT_FOUND_MESSAGE = "존재하지 않는 회원입니다.";
     public static final String PASSWORD_MISMATCH_MESSAGE = "비밀번호가 일치하지 않습니다.";
 
     // 성공 메시지

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/NoiseController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/NoiseController.java
@@ -116,7 +116,7 @@ public class NoiseController {
             return ResponseEntity.ok(ResponseDTO.success(200, "적대적 노이즈 삽입 성공", createdNoise));
 
         } catch (Exception e) {
-            log.error("❌ 적대적 노이즈 생성 중 오류 발생: ", e);
+            log.error("적대적 노이즈 생성 중 오류 발생: ", e);
             return ResponseEntity.status(500)
                     .body(ResponseDTO.fail(500, "서버 오류: " + e.getMessage()));
         }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/UserController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/UserController.java
@@ -5,11 +5,17 @@ import com.deeptruth.deeptruth.base.dto.login.LoginResponse;
 import com.deeptruth.deeptruth.base.dto.login.RefreshTokenRequest;
 import com.deeptruth.deeptruth.base.dto.signup.SignupRequestDTO;
 import com.deeptruth.deeptruth.base.dto.response.ResponseDTO;
+import com.deeptruth.deeptruth.base.dto.user.UserUpdateRequest;
+import com.deeptruth.deeptruth.base.exception.DuplicateNicknameException;
+import com.deeptruth.deeptruth.config.CustomUserDetails;
 import com.deeptruth.deeptruth.entity.User;
 import com.deeptruth.deeptruth.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import com.deeptruth.deeptruth.base.dto.user.UserProfile;
 import org.springframework.security.core.Authentication;
@@ -39,80 +45,95 @@ public class UserController {
 
     @PostMapping("/auth/login")
     public ResponseEntity<ResponseDTO<LoginResponse>> login(@RequestBody LoginRequestDTO request) {
-        try {
-            LoginResponse loginResponse = userService.login(request);
+        LoginResponse loginResponse = userService.login(request);
 
-            return ResponseEntity.ok(
-                    ResponseDTO.success(
-                            HttpStatus.OK.value(),
-                            LOGIN_SUCCESS_MESSAGE,
-                            loginResponse
-                    )
-            );
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(
-                    ResponseDTO.fail(
-                            HttpStatus.BAD_REQUEST.value(),
-                            e.getMessage()
-                    )
-            );
-        }
+        return ResponseEntity.ok(
+                ResponseDTO.success(
+                        HttpStatus.OK.value(),
+                        LOGIN_SUCCESS_MESSAGE,
+                        loginResponse
+                )
+        );
     }
 
     @PostMapping("/auth/refresh")
     public ResponseEntity<ResponseDTO<LoginResponse>> refreshToken(@RequestBody RefreshTokenRequest request) {
-        try {
-            LoginResponse response = userService.refreshAccessToken(request.getRefreshToken());
-            return ResponseEntity.ok(
-                    ResponseDTO.success(HttpStatus.OK.value(), "토큰 재발급 성공", response));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(
-                    ResponseDTO.fail(HttpStatus.BAD_REQUEST.value(), e.getMessage()));
-        }
+        LoginResponse response = userService.refreshAccessToken(request.getRefreshToken());
+        return ResponseEntity.ok(
+                ResponseDTO.success(HttpStatus.OK.value(), "토큰 재발급 성공", response));
+    }
+
+    // 회원정보 수정
+    @PutMapping("/users")
+    public ResponseEntity<ResponseDTO<String>> updateUser(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UserUpdateRequest request) {
+
+        Long userId = userDetails.getUserId();
+
+        User user = userService.findUserById(userId);  // UserNotFoundException 발생 가능
+        userService.updateUser(user, request);         // DuplicateNicknameException 발생 가능
+
+        return ResponseEntity.ok(
+                ResponseDTO.success(HttpStatus.OK.value(), "회원정보가 성공적으로 변경되었습니다.", null)
+        );
+    }
+
+    // 회원 탈퇴
+    @DeleteMapping("/users")
+    public ResponseEntity<ResponseDTO<String>> deleteUser(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        User user = userService.findUserById(userId);
+        userService.deleteUser(user);
+
+        return ResponseEntity.ok(
+                ResponseDTO.success(HttpStatus.OK.value(), "회원 탈퇴가 완료되었습니다.", null)
+        );
     }
 
     @PostMapping("/auth/logout")
-    public ResponseEntity<ResponseDTO<String>> logout(@RequestBody RefreshTokenRequest request) {
-        try {
-            userService.logout(request.getRefreshToken());
-            return ResponseEntity.ok(
-                    ResponseDTO.success(HttpStatus.OK.value(), "로그아웃 완료", "성공적으로 로그아웃되었습니다."));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(
-                    ResponseDTO.fail(HttpStatus.BAD_REQUEST.value(), e.getMessage()));
-        }
+    public ResponseEntity<ResponseDTO<String>> logout(
+            @RequestBody RefreshTokenRequest request) {
+        userService.logout(request.getRefreshToken());
+        return ResponseEntity.ok(
+                ResponseDTO.success(HttpStatus.OK.value(), "로그아웃 완료", "성공적으로 로그아웃되었습니다."));
     }
 
     // 상세 정보
     @GetMapping("/users/profile")
-    public ResponseEntity<ResponseDTO<UserProfile>> getUserProfile(Authentication authentication) {
-        try {
-            User user = (User) authentication.getPrincipal();
+    public ResponseEntity<ResponseDTO<UserProfile>> getUserProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-            UserProfile profile = UserProfile.builder()
-                    .userId(user.getUserId())
-                    .loginId(user.getLoginId())
-                    .name(user.getName())
-                    .nickname(user.getNickname())
-                    .email(user.getEmail())
-                    .role(user.getRole())
-                    .build();
+        User user = userDetails.getUser();
 
-            return ResponseEntity.ok(
-                    ResponseDTO.success(HttpStatus.OK.value(), "프로필 조회 성공", profile)
-            );
-        } catch (Exception e) {
-            return ResponseEntity.badRequest()
-                    .body(ResponseDTO.fail(HttpStatus.BAD_REQUEST.value(), "프로필 조회 실패"));
-        }
+        UserProfile profile = UserProfile.builder()
+                .userId(user.getUserId())
+                .loginId(user.getLoginId())
+                .name(user.getName())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .role(user.getRole())
+                .level(user.getLevel())
+                .point(user.getPoint())
+                .signature(user.getSignature())
+                .socialLoginType(user.getSocialLoginType())
+                .createdAt(user.getCreatedAt())
+                .build();
+
+        return ResponseEntity.ok(
+                ResponseDTO.success(HttpStatus.OK.value(), "프로필 조회 성공", profile)
+        );
     }
+
 
     // 로그인한 사용자 확인
     @GetMapping("/users/me")
-    public ResponseEntity<ResponseDTO<String>> getCurrentUser(Authentication authentication) {
-        User user = (User) authentication.getPrincipal();
+    public ResponseEntity<ResponseDTO<String>> getCurrentUser(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
         return ResponseEntity.ok(
-                ResponseDTO.success(HttpStatus.OK.value(), "인증된 사용자", user.getLoginId())
+                ResponseDTO.success(HttpStatus.OK.value(), "인증된 사용자", userDetails.getUsername())
         );
     }
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/User.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/User.java
@@ -5,8 +5,11 @@ import com.deeptruth.deeptruth.base.Enum.Role;
 import com.deeptruth.deeptruth.base.Enum.SocialLoginType;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Builder
@@ -15,6 +18,8 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "user")
+@SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE user_id = ?")
+@SQLRestriction("deleted_at IS NULL")
 public class User {
 
     @Id
@@ -61,4 +66,7 @@ public class User {
     protected void onCreate() {
         this.createdAt = LocalDate.now();
     }
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/CustomUserDetailsService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/CustomUserDetailsService.java
@@ -1,0 +1,25 @@
+package com.deeptruth.deeptruth.service;
+
+import com.deeptruth.deeptruth.config.CustomUserDetails;
+import com.deeptruth.deeptruth.entity.User;
+import com.deeptruth.deeptruth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + loginId));
+
+        return new CustomUserDetails(user);
+    }
+}

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/UserControllerTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/UserControllerTest.java
@@ -3,24 +3,40 @@ package com.deeptruth.deeptruth.controller;
 import static com.deeptruth.deeptruth.constants.LoginConstants.*;
 import static com.deeptruth.deeptruth.constants.SignupConstants.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
+import com.deeptruth.deeptruth.base.Enum.Level;
+import com.deeptruth.deeptruth.base.Enum.Role;
+import com.deeptruth.deeptruth.base.Enum.SocialLoginType;
 import com.deeptruth.deeptruth.base.dto.login.LoginRequestDTO;
+import com.deeptruth.deeptruth.base.dto.login.LoginResponse;
 import com.deeptruth.deeptruth.base.dto.signup.SignupRequestDTO;
+import com.deeptruth.deeptruth.base.dto.user.UserUpdateRequest;
+import com.deeptruth.deeptruth.config.CustomUserDetails;
+import com.deeptruth.deeptruth.config.JwtAuthenticationFilter;
+import com.deeptruth.deeptruth.entity.User;
 import com.deeptruth.deeptruth.service.UserService;
+import com.deeptruth.deeptruth.util.JwtUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import static org.mockito.ArgumentMatchers.any;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
 
 @WebMvcTest(controllers = UserController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -32,19 +48,41 @@ public class UserControllerTest {
     @MockitoBean
     private UserService userService;
 
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
     @Autowired
     private ObjectMapper objectMapper;
 
+    // SecurityContext 설정 헬퍼 메서드
+    private void setUpSecurityContext(Long userId, String loginId) {
+        User mockUser = User.builder()
+                .userId(userId)
+                .loginId(loginId)
+                .role(Role.USER)
+                .build();
+
+        CustomUserDetails customUserDetails = new CustomUserDetails(mockUser);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                customUserDetails, null, customUserDetails.getAuthorities());
+
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        securityContext.setAuthentication(authentication);
+        SecurityContextHolder.setContext(securityContext);
+    }
+
     @Test
-    @DisplayName("회원가입 API 성공 테스트")
-    void signupApiSuccess() throws Exception {
+    void 회원가입_성공() throws Exception {
         // given
         SignupRequestDTO request = new SignupRequestDTO(
                 "홍길동", "userid123", "Password1!", "Password1!", "tester", "test@example.com"
         );
 
         // when & then
-        mockMvc.perform(post("/api/signup")
+        mockMvc.perform(post("/api/auth/signup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -57,32 +95,36 @@ public class UserControllerTest {
     }
 
     @Test
-    @DisplayName("로그인 API 성공 테스트")
-    void loginApiSuccess() throws Exception {
+    void 로그인_성공() throws Exception {
         // given
         LoginRequestDTO loginRequest = new LoginRequestDTO();
         loginRequest.setLoginId("testuser123");
         loginRequest.setPassword("Password1!");
 
-//        when(userService.login(any(LoginRequestDTO.class)))
-//                .thenReturn("mocked.jwt.token");
+        LoginResponse mockLoginResponse = new LoginResponse(
+                "mocked.access.token",
+                "mocked.refresh.token"
+        );
+
+        when(userService.login(any(LoginRequestDTO.class)))
+                .thenReturn(mockLoginResponse);
 
         // when & then
-        mockMvc.perform(post("/api/login")
+        mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value(LOGIN_SUCCESS_MESSAGE))
-                .andExpect(jsonPath("$.data").value("mocked.jwt.token"));
+                .andExpect(jsonPath("$.data.accessToken").value("mocked.access.token"))
+                .andExpect(jsonPath("$.data.refreshToken").value("mocked.refresh.token"));
 
         verify(userService).login(any(LoginRequestDTO.class));
     }
 
     @Test
-    @DisplayName("로그인 API 실패 테스트 - 존재하지 않는 아이디")
-    void loginApiFailure_UserNotFound() throws Exception {
+    void 로그인_실패_존재하지않는_아이디() throws Exception {
         // given
         LoginRequestDTO loginRequest = new LoginRequestDTO();
         loginRequest.setLoginId("nonexistent");
@@ -92,7 +134,7 @@ public class UserControllerTest {
                 .thenThrow(new IllegalArgumentException(USER_NOT_FOUND_MESSAGE));
 
         // when & then
-        mockMvc.perform(post("/api/login")
+        mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isBadRequest())
@@ -105,8 +147,7 @@ public class UserControllerTest {
     }
 
     @Test
-    @DisplayName("로그인 API 실패 테스트 - 잘못된 비밀번호")
-    void loginApiFailure_InvalidPassword() throws Exception {
+    void 로그인_실패_잘못된_비밀번호() throws Exception {
         // given
         LoginRequestDTO loginRequest = new LoginRequestDTO();
         loginRequest.setLoginId("testuser123");
@@ -116,7 +157,10 @@ public class UserControllerTest {
                 .thenThrow(new IllegalArgumentException(PASSWORD_MISMATCH_MESSAGE));
 
         // when & then
-        mockMvc.perform(post("/api/login")
+        mockMvc.perform(post("/api/auth/login")
+                        .with(jwt().jwt(builder -> builder
+                                .claim("sub", "testuser")
+                                .claim("scope", "read")))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isBadRequest())
@@ -126,6 +170,99 @@ public class UserControllerTest {
                 .andExpect(jsonPath("$.data").isEmpty());
 
         verify(userService).login(any(LoginRequestDTO.class));
+    }
+
+    @Test
+    void 회원정보_수정_성공() throws Exception {
+        // given
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setNickname("새닉네임");
+
+        User mockUser = User.builder()
+                .userId(1L)
+                .loginId("testuser123")
+                .nickname("기존닉네임")
+                .role(Role.USER)
+                .build();
+
+        // SecurityContext 설정
+        setUpSecurityContext(1L, "testuser123");
+
+        // UserService 모킹
+        when(userService.findUserById(1L)).thenReturn(mockUser);
+        doNothing().when(userService).updateUser(any(User.class), any(UserUpdateRequest.class));
+
+        // when & then
+        mockMvc.perform(put("/api/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("회원정보가 성공적으로 변경되었습니다."));
+
+        verify(userService).findUserById(1L);
+        verify(userService).updateUser(any(User.class), any(UserUpdateRequest.class));
+    }
+
+    @Test
+    void 회원탈퇴_성공() throws Exception {
+        // given
+        User mockUser = User.builder()
+                .userId(1L)
+                .loginId("testuser123")
+                .role(Role.USER)
+                .build();
+
+        setUpSecurityContext(1L, "testuser123");
+
+        when(userService.findUserById(1L)).thenReturn(mockUser);
+        doNothing().when(userService).deleteUser(any(User.class));
+
+        // when & then
+        mockMvc.perform(delete("/api/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("회원 탈퇴가 완료되었습니다."));
+
+        verify(userService).findUserById(1L);
+        verify(userService).deleteUser(any(User.class));
+    }
+
+    @Test
+    void 회원_프로필_조회_성공() throws Exception {
+        // given
+        User mockUser = User.builder()
+                .userId(1L)
+                .loginId("testuser123")
+                .name("홍길동")
+                .nickname("테스터")
+                .email("test@example.com")
+                .role(Role.USER)
+                .level(Level.EXPLORER)
+                .point(100)
+                .signature("안녕하세요")
+                .socialLoginType(SocialLoginType.NONE)
+                .createdAt(LocalDate.now())
+                .build();
+
+        CustomUserDetails customUserDetails = new CustomUserDetails(mockUser);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                customUserDetails, null, customUserDetails.getAuthorities());
+
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        securityContext.setAuthentication(authentication);
+        SecurityContextHolder.setContext(securityContext);
+
+        // when & then
+        mockMvc.perform(get("/api/users/profile"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.userId").value(1))
+                .andExpect(jsonPath("$.data.loginId").value("testuser123"))
+                .andExpect(jsonPath("$.data.name").value("홍길동"))
+                .andExpect(jsonPath("$.data.nickname").value("테스터"))
+                .andExpect(jsonPath("$.data.level").value("EXPLORER"))
+                .andExpect(jsonPath("$.data.point").value(100));
     }
 
 }

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/service/UserServiceTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/service/UserServiceTest.java
@@ -1,15 +1,18 @@
 package com.deeptruth.deeptruth.service;
 
 import com.deeptruth.deeptruth.base.Enum.Role;
+import com.deeptruth.deeptruth.base.Enum.SocialLoginType;
 import com.deeptruth.deeptruth.base.OAuth.OAuth2UserInfo;
 import com.deeptruth.deeptruth.base.dto.login.LoginRequestDTO;
 import com.deeptruth.deeptruth.base.dto.login.LoginResponse;
+import com.deeptruth.deeptruth.base.dto.user.UserUpdateRequest;
+import com.deeptruth.deeptruth.base.exception.*;
 import com.deeptruth.deeptruth.entity.RefreshToken;
 import com.deeptruth.deeptruth.entity.User;
 import com.deeptruth.deeptruth.repository.RefreshTokenRepository;
 import com.deeptruth.deeptruth.repository.UserRepository;
 import com.deeptruth.deeptruth.util.JwtUtil;
-import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,10 +21,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.deeptruth.deeptruth.base.dto.signup.SignupRequestDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static com.deeptruth.deeptruth.constants.LoginConstants.*;
@@ -37,6 +41,8 @@ public class UserServiceTest {
 
     @InjectMocks
     private UserService userService;
+
+    private User testUser;
 
     @Mock
     private PasswordEncoder passwordEncoder;
@@ -230,6 +236,313 @@ public class UserServiceTest {
         }
     }
 
+    // 회원 수정 테스트
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .userId(1L)
+                .name("홍길동")
+                .loginId("testuser123")
+                .password("encodedPassword")
+                .nickname("기존닉네임")
+                .email("test@example.com")
+                .role(Role.USER)
+                .socialLoginType(SocialLoginType.NONE)
+                .build();
+    }
+
+    @Test
+    void 회원수정_성공_닉네임변경() {
+        // given
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setNickname("새로운닉네임");
+
+        when(userRepository.existsByNickname("새로운닉네임")).thenReturn(false);
+        when(userRepository.save(testUser)).thenReturn(testUser);
+
+        // when
+        assertDoesNotThrow(() -> userService.updateUser(testUser, request));
+
+        // then
+        assertEquals("새로운닉네임", testUser.getNickname());
+        verify(userRepository).existsByNickname("새로운닉네임");
+        verify(userRepository).save(testUser);
+    }
+
+    @Test
+    void 회원수정_실패_중복닉네임() {
+        // given
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setNickname("중복된닉네임");
+
+        when(userRepository.existsByNickname("중복된닉네임")).thenReturn(true);
+
+        // when & then
+        DuplicateNicknameException exception = assertThrows(
+                DuplicateNicknameException.class,
+                () -> userService.updateUser(testUser, request)
+        );
+
+        assertEquals("이미 사용 중인 닉네임입니다.", exception.getMessage());
+        verify(userRepository).existsByNickname("중복된닉네임");
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void 회원수정_성공_이메일변경() {
+        // given
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setEmail("newemail@example.com");
+
+        when(userRepository.existsByEmail("newemail@example.com")).thenReturn(false);
+        when(userRepository.save(testUser)).thenReturn(testUser);
+
+        // when
+        assertDoesNotThrow(() -> userService.updateUser(testUser, request));
+
+        // then
+        assertEquals("newemail@example.com", testUser.getEmail());
+        verify(userRepository).existsByEmail("newemail@example.com");
+        verify(userRepository).save(testUser);
+    }
+
+    @Test
+    void 회원수정_실패_중복이메일() {
+        // given
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setEmail("duplicate@example.com");
+
+        when(userRepository.existsByEmail("duplicate@example.com")).thenReturn(true);
+
+        // when & then
+        DuplicateEmailException exception = assertThrows(
+                DuplicateEmailException.class,
+                () -> userService.updateUser(testUser, request)
+        );
+
+        assertEquals("이미 사용 중인 이메일입니다.", exception.getMessage());
+        verify(userRepository).existsByEmail("duplicate@example.com");
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void 회원수정_실패_소셜로그인사용자_이메일변경시도() {
+        // given
+        testUser.setSocialLoginType(SocialLoginType.GOOGLE); // 소셜 로그인 사용자로 설정
+
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setEmail("newemail@example.com");
+
+        // when & then
+        UnauthorizedOperationException exception = assertThrows(
+                UnauthorizedOperationException.class,
+                () -> userService.updateUser(testUser, request)
+        );
+
+        assertEquals("소셜 로그인 사용자는 이메일을 변경할 수 없습니다.", exception.getMessage());
+        verify(userRepository, never()).existsByEmail(anyString());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void 회원수정_성공_비밀번호변경() {
+        // given
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setCurrentPassword("Password1!");
+        request.setNewPassword("NewPassword123!");
+        request.setNewPasswordConfirm("NewPassword123!");
+
+        when(passwordEncoder.matches("Password1!", "encodedPassword")).thenReturn(true);
+        when(passwordEncoder.encode("NewPassword123!")).thenReturn("newEncodedPassword");
+        when(userRepository.save(testUser)).thenReturn(testUser);
+
+        // when
+        assertDoesNotThrow(() -> userService.updateUser(testUser, request));
+
+        // then
+        assertEquals("newEncodedPassword", testUser.getPassword());
+        verify(passwordEncoder).matches("Password1!", "encodedPassword");
+        verify(passwordEncoder).encode("NewPassword123!");
+        verify(userRepository).save(testUser);
+    }
+
+    @Test
+    void 회원수정_실패_현재비밀번호불일치() {
+        // given
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setCurrentPassword("WrongPassword!");
+        request.setNewPassword("NewPassword123!");
+        request.setNewPasswordConfirm("NewPassword123!");
+
+        when(passwordEncoder.matches("WrongPassword!", "encodedPassword")).thenReturn(false);
+
+        // when & then
+        InvalidPasswordException exception = assertThrows(
+                InvalidPasswordException.class,
+                () -> userService.updateUser(testUser, request)
+        );
+
+        assertEquals("현재 비밀번호가 일치하지 않습니다.", exception.getMessage());
+        verify(passwordEncoder).matches("WrongPassword!", "encodedPassword");
+        verify(passwordEncoder, never()).encode(anyString());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void 회원수정_실패_새비밀번호불일치() {
+        // given
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setCurrentPassword("Password1!");
+        request.setNewPassword("NewPassword123!");
+        request.setNewPasswordConfirm("DifferentPassword!");
+
+        when(passwordEncoder.matches("Password1!", "encodedPassword")).thenReturn(true);
+
+        // when & then
+        InvalidPasswordException exception = assertThrows(
+                InvalidPasswordException.class,
+                () -> userService.updateUser(testUser, request)
+        );
+
+        assertEquals("새 비밀번호 확인이 일치하지 않습니다.", exception.getMessage());
+        verify(passwordEncoder).matches("Password1!", "encodedPassword");
+        verify(passwordEncoder, never()).encode(anyString());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void 회원수정_실패_새비밀번호가_현재비밀번호와_동일() {
+        // given
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setCurrentPassword("Password1!");
+        request.setNewPassword("Password1!");
+        request.setNewPasswordConfirm("Password1!");
+
+        // 현재 비밀번호 검증은 성공하도록 설정
+        when(passwordEncoder.matches("Password1!", "encodedPassword")).thenReturn(true);
+
+        // when & then
+        InvalidPasswordException exception = assertThrows(
+                InvalidPasswordException.class,
+                () -> userService.updateUser(testUser, request)
+        );
+
+        assertEquals("새 비밀번호는 현재 비밀번호와 달라야 합니다.", exception.getMessage());
+
+        verify(passwordEncoder).matches("Password1!", "encodedPassword");
+        verify(passwordEncoder, never()).encode(anyString());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+
+    @Test
+    void 회원수정_실패_소셜로그인사용자_비밀번호변경시도() {
+        // given
+        testUser.setSocialLoginType(SocialLoginType.GOOGLE); // 소셜 로그인 사용자로 설정
+
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setCurrentPassword("Password1!");
+        request.setNewPassword("NewPassword123!");
+        request.setNewPasswordConfirm("NewPassword123!");
+
+        // when & then
+        UnauthorizedOperationException exception = assertThrows(
+                UnauthorizedOperationException.class,
+                () -> userService.updateUser(testUser, request)
+        );
+
+        assertEquals("소셜 로그인 사용자는 비밀번호를 변경할 수 없습니다.", exception.getMessage());
+        verify(passwordEncoder, never()).matches(anyString(), anyString());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    // 회원 탈퇴 테스트
+
+    @Test
+    void 회원탈퇴_성공_SoftDelete() {
+        // given
+        User user = User.builder()
+                .userId(1L)
+                .loginId("testuser")
+                .email("test@example.com")
+                .deletedAt(null)  // 초기에는 삭제되지 않은 상태
+                .build();
+
+        // when
+        assertDoesNotThrow(() -> userService.deleteUser(user));
+
+        // then - Repository 호출 확인만 (실제 deletedAt 설정은 @SQLDelete가 처리)
+        verify(refreshTokenRepository).deleteByUser(user);
+        verify(userRepository).delete(user);  // 이것이 실제로는 UPDATE 쿼리가 됨
+    }
+
+    @Test
+    void 삭제된_사용자는_조회되지_않음() {
+        // given
+        String loginId = "deleteduser";
+        when(userRepository.findByLoginId(loginId)).thenReturn(Optional.empty());
+
+        // when
+        Optional<User> result = userRepository.findByLoginId(loginId);
+
+        // then
+        assertTrue(result.isEmpty());
+        verify(userRepository).findByLoginId(loginId);
+    }
+
+    @Test
+    void 활성_사용자만_조회() {
+        // given - @SQLRestriction으로 자동 필터링되는 활성 사용자들만 목킹
+        List<User> activeUsers = Arrays.asList(
+                User.builder().userId(1L).loginId("user1").deletedAt(null).build(),
+                User.builder().userId(2L).loginId("user2").deletedAt(null).build()
+        );
+
+        when(userRepository.findAll()).thenReturn(activeUsers);
+
+        // when
+        List<User> result = userRepository.findAll();
+
+        // then
+        assertEquals(2, result.size());
+        assertTrue(result.stream().allMatch(user -> user.getDeletedAt() == null));
+    }
+
+
+    // 회원 조회 테스트
+
+    @Test
+    void 회원조회_성공() {
+        // given
+        when(userRepository.findById(1L)).thenReturn(java.util.Optional.of(testUser));
+
+        // when
+        User result = userService.findUserById(1L);
+
+        // then
+        assertNotNull(result);
+        assertEquals(testUser.getUserId(), result.getUserId());
+        assertEquals(testUser.getLoginId(), result.getLoginId());
+        assertEquals(testUser.getNickname(), result.getNickname());
+        verify(userRepository).findById(1L);
+    }
+
+    @Test
+    void 회원조회_실패_사용자없음() {
+        // given
+        when(userRepository.findById(999L)).thenReturn(java.util.Optional.empty());
+
+        // when & then
+        UserNotFoundException exception = assertThrows(
+                UserNotFoundException.class,
+                () -> userService.findUserById(999L)
+        );
+
+        // UserNotFoundException의 메시지는 생성자에 따라 다를 수 있음
+        verify(userRepository).findById(999L);
+    }
+
     // 로그인 테스트
     /*
     @Test
@@ -320,8 +633,8 @@ public class UserServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userService.login(loginRequest))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining(USER_NOT_FOUND_MESSAGE);
+                .isInstanceOf(UserNotFoundException.class)
+                .hasMessageContaining("User not found");
 
         verify(userRepository).findByLoginId(loginId);
     }
@@ -350,7 +663,7 @@ public class UserServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userService.login(loginRequest))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(InvalidPasswordException.class)
                 .hasMessageContaining("비밀번호가 일치하지 않습니다.");
 
         verify(userRepository).findByLoginId(loginId);


### PR DESCRIPTION
## 📝 Summary
> TDD 방식으로 회원 정보 수정 및 탈퇴 API를 구현했습니다. 통합 API 설계로 선택적 필드 업데이트를 지원하며, 소셜/일반 로그인 사용자별 권한 구분 처리, Soft Delete 기반 회원 탈퇴, 프로필 조회 API 확장을 포함합니다.

## 💻 Describe your changes
**1. 핵심 API 구현**
- PUT /api/users: 통합 회원정보 수정 API
  - 비밀번호, 이메일, 닉네임 선택적 업데이트 지원
  - 소셜 로그인 사용자는 이메일/비밀번호 변경 제한
  - 현재 비밀번호 검증 및 중복 체크 로직 포함
- DELETE /api/users: 회원 탈퇴 API (Soft Delete)
- GET /api/users/profile: 프로필 조회 API 확장
  - level, point, signature, socialLoginType, createdAt 필드 추가
<br></br>

**2. 예외 처리 강화**
- 커스텀 예외 클래스 추가: DuplicateEmailException, DuplicateNicknameException, InvalidPasswordException, UnauthorizedOperationException
- GlobalExceptionHandler 개선: 구체적인 HTTP 상태코드 매핑
-> 기존 UserNotFoundException이 404 Not Found로 반환되던 부분을 **401 Unauthorized**로 개선했습니다. 특히 JWT 인증 과정에서 사용자를 찾을 수 없는 경우 인증 실패로 처리하도록 아래와 같이 @ExceptionHandler를 추가했습니다.
```
@ExceptionHandler(UserNotFoundException.class)
public ResponseEntity<ResponseDTO> handleUserNotFoundException(RuntimeException ex) {
    log.info("[401] {}", ex.getMessage());
    return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
            .body(ResponseDTO.fail(401, "존재하지 않는 회원입니다."));
}
```
| HTTP Status | 의미 | 처리 예외 | 설명 |
|-------------|------|-----------|------|
| 400 | Bad Request | InvalidFileException, ImageDecodingException, IllegalArgumentException | 잘못된 요청 |
| 401 | Unauthorized | UserNotFoundException, InvalidPasswordException | 인증 실패 |
| 403 | Forbidden | UnauthorizedOperationException | 권한 부족 |
| 404 | Not Found | DetectionNotFoundException, WatermarkNotFoundException, NoiseNotFoundException | 리소스 없음 |
| 409 | Conflict | DuplicateEmailException, DuplicateNicknameException | 중복 리소스 |
| 422 | Unprocessable Entity | InvalidDetectionResponseException, InvalidWatermarkResponseException | 비즈니스 규칙 위반 |
| 502 | Bad Gateway | StorageException, ExternalServiceException | 외부 서비스 오류 |
| 500 | Internal Server Error | Exception (기타 모든 예외) | 서버 내부 오류 |
<br></br>

**3. 인증 및 보안 강화**
- JWT 인증 필터 개선: 탈퇴 사용자 접근 차단 처리
- CustomUserDetailsService 구현으로 Spring Security 연동 강화
- SecurityConfig 최적화: 필터 체인 및 경로별 권한 설정

**4. 테스트 완료 현황**
- Postman 테스트 완료: 모든 API 엔드포인트 정상 동작 확인
  - 회원정보 수정 (비밀번호/이메일/닉네임 개별 및 통합 테스트)
  - 회원 탈퇴 및 Soft Delete 검증
  - 프로필 조회 확장 필드 확인
  - 예외 상황별 적절한 HTTP 상태코드 반환 검증
- 일반 로그인 사용자 시나리오 전체 테스트 완료
- 소셜 로그인 사용자 테스트: 배포 후 실제 OAuth 환경에서 테스트 예정

## #️⃣ Issue number and link
> #94 

## 💬 Message to the Reviewer
1. GlobalExceptionHandler의 개선 사항(404 → 401)이 다른 기능에 영향을 주지 않는지 확인 부탁드립니다. 혹시 더 나은 예외 처리 패턴이나 개선 방향이 있다면 조언 부탁드립니다.

2. 연관 데이터(워터마크, 적대적 노이즈 등)의 Cascade 처리를 고려하여 물리적 삭제 대신 Soft Delete 방식을 적용했습니다. @SQLDelete와 @SQLRestriction 애노테이션을 활용한 현재 구현 방식이 적절한지, 그리고 향후 데이터 정합성 관점에서 문제가 없는지 검토 부탁드립니다.
