### PR TITLE
Refacotr: 딥페이크 결과 상세 저장 및 차트 계산 도입 

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/BulletDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/BulletDTO.java
@@ -1,0 +1,21 @@
+package com.deeptruth.deeptruth.base.dto.deepfake;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BulletDTO {
+    private String key;
+    private String label;
+    private Float value;
+    private Map<String, float[]> bands; // good/warn/bad
+    private String direction;            // "lower" | "higher"
+    private String unit;                 // "fps" | "ms" | null
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/DeepfakeDetectionDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/DeepfakeDetectionDTO.java
@@ -11,33 +11,87 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 
 @Getter
 @Builder
 public class DeepfakeDetectionDTO {
     private Long id;
+    private String taskId;
     private String filePath;
+    private LocalDateTime createdAt;
     private DeepfakeResult result;
+
+    private Float scoreWeighted;
+    private Float thresholdTau;
+    private Float frameVoteRatio;
+
     private Float averageConfidence;
     private Float maxConfidence;
-    private LocalDateTime createdAt;
+    private Float medianConfidence;
+    private Float varianceConfidence;
+
+    private Integer framesProcessed;
+    private Float processingTimeSec;
+
+    private Float fpsProcessed;
+    private Float msPerSample;
+    private Float targetFpsUsed;
+    private Float maxLatencyMsUsed;
+    private Boolean speedOk;
+
+    private Float temporalDeltaMean;
+    private Float temporalDeltaStd;
+    private Float ttaMean;
+    private Float ttaStd;
+
+    private String timeseriesJson;
+
+    private Float speedScore;
+    private Float stabilityScore;
+
     private DeepfakeMode mode;
+    private DeepfakeDetector detector;
     private Boolean useTta;
     private Boolean useIllum;
-    private DeepfakeDetector detector;
     private Integer smoothWindow;
     private Integer minFace;
     private Integer sampleCount;
-    private String taskId;
 
-    public static DeepfakeDetectionDTO fromEntity(DeepfakeDetection entity) {
+    private List<BulletDTO> stabilityBullets;
+    private List<BulletDTO> speedBullets;
+
+    public static DeepfakeDetectionDTO fromEntity(DeepfakeDetection entity,
+                                                  List<BulletDTO> stability,
+                                                  List<BulletDTO> speed) {
         return DeepfakeDetectionDTO.builder()
                 .id(entity.getDeepfakeDetectionId())
+                .taskId(entity.getTaskId())
                 .filePath(entity.getFilePath())
                 .result(entity.getResult())
+                .createdAt(entity.getCreatedAt())
+                .scoreWeighted(entity.getScoreWeighted())
+                .thresholdTau(entity.getThresholdTau())
+                .frameVoteRatio(entity.getFrameVoteRatio())
                 .averageConfidence(entity.getAverageConfidence())
                 .maxConfidence(entity.getMaxConfidence())
-                .createdAt(entity.getCreatedAt())
+                .medianConfidence(entity.getMedianConfidence())
+                .varianceConfidence(entity.getVarianceConfidence())
+                .framesProcessed(entity.getFramesProcessed())
+                .processingTimeSec(entity.getProcessingTimeSec())
+                .fpsProcessed(entity.getFpsProcessed())
+                .msPerSample(entity.getMsPerSample())
+                .targetFpsUsed(entity.getTargetFpsUsed())
+                .maxLatencyMsUsed(entity.getMaxLatencyMsUsed())
+                .speedOk(entity.getSpeedOk())
+                .temporalDeltaMean(entity.getTemporalDeltaMean())
+                .temporalDeltaStd(entity.getTemporalDeltaStd())
+                .ttaMean(entity.getTtaMean())
+                .ttaStd(entity.getTtaStd())
+                .timeseriesJson(entity.getTimeseriesJson())
+                .speedScore(entity.getSpeedScore())
+                .stabilityScore(entity.getStabilityScore())
                 .mode(entity.getMode())
                 .useTta(entity.getUseTta())
                 .useIllum(entity.getUseIllum())
@@ -45,7 +99,8 @@ public class DeepfakeDetectionDTO {
                 .smoothWindow(entity.getSmoothWindow())
                 .minFace(entity.getMinFace())
                 .sampleCount(entity.getSampleCount())
-                .taskId(entity.getTaskId())
+                .speedBullets(speed)
+                .stabilityBullets(stability)
                 .build();
     }
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/DeepfakeDetectionListDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/DeepfakeDetectionListDTO.java
@@ -1,0 +1,30 @@
+package com.deeptruth.deeptruth.base.dto.deepfake;
+
+import com.deeptruth.deeptruth.base.Enum.DeepfakeMode;
+import com.deeptruth.deeptruth.base.Enum.DeepfakeResult;
+import com.deeptruth.deeptruth.entity.DeepfakeDetection;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class DeepfakeDetectionListDTO {
+    private Long id;
+    private String taskId;
+    private String filePath;
+    private LocalDateTime createdAt;
+    private DeepfakeResult result;
+    private DeepfakeMode deepfakeMode;
+
+    public static DeepfakeDetectionListDTO fromEntity(DeepfakeDetection entity){
+        return DeepfakeDetectionListDTO.builder()
+                .id(entity.getDeepfakeDetectionId())
+                .taskId(entity.getTaskId())
+                .filePath(entity.getFilePath())
+                .result(entity.getResult())
+                .deepfakeMode(entity.getMode())
+                .build();
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/FlaskResponseDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/FlaskResponseDTO.java
@@ -12,38 +12,34 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 public class FlaskResponseDTO {
+    @JsonProperty("taskId") private String taskId;
     private DeepfakeResult result;
+    private String imageUrl;
+    @JsonProperty("most_suspect_image") private String base64Url;
 
-    @JsonProperty("average_fake_confidence")
-    private Float averageConfidence;
 
-    @JsonProperty("max_confidence")
-    private Float maxConfidence;
+    @JsonProperty("score_weighted") private Float scoreWeighted;
+    @JsonProperty("threshold_tau") private Float thresholdTau;
+    @JsonProperty("frame_vote_ratio") private Float frameVoteRatio;
 
-    @JsonProperty("most_suspect_image")
-    private String base64Url;
+    @JsonProperty("average_fake_confidence") private Float averageConfidence;
+    @JsonProperty("median_confidence") private Float medianConfidence;
+    @JsonProperty("max_confidence") private Float maxConfidence;
+    @JsonProperty("variance_confidence") private Float varianceConfidence;
+
+    @JsonProperty("frames_processed") private Integer framesProcessed;
+    @JsonProperty("processing_time_sec") private Float processingTimeSec;
 
     private String detector;
-
-    @JsonProperty("min_face")
-    private Integer minFace;
-
     private String mode;
+    @JsonProperty("min_face") private Integer minFace;
+    @JsonProperty("sample_count") private Integer sampleCount;
+    @JsonProperty("smooth_window") private Integer smoothWindow;
+    @JsonProperty("use_illum") private Boolean useIllum;
+    @JsonProperty("use_tta") private Boolean useTta;
 
-    @JsonProperty("sample_count")
-    private Integer sampleCount;
+    @JsonProperty("timeseries") private Timeseries timeseries;
+    @JsonProperty("stability_evidence") private StabilityEvidence stabilityEvidence;
+    @JsonProperty("speed") private Speed speed;
 
-    @JsonProperty("smooth_window")
-    private Integer smoothWindow;
-
-    @JsonProperty("use_illum")
-    private Boolean useIllum;
-
-    @JsonProperty("use_tta")
-    private Boolean useTta;
-
-    @JsonProperty("taskId")
-    private String taskId;
-
-    private String imageUrl;
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/Speed.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/Speed.java
@@ -1,0 +1,29 @@
+package com.deeptruth.deeptruth.base.dto.deepfake;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Speed {
+    @JsonProperty("fps_processed")
+    private Float fpsProcessed;
+
+    @JsonProperty("ms_per_sample")
+    private Float msPerSample;
+
+    @JsonProperty("target_fps")
+    private Float targetFps;
+
+    @JsonProperty("max_latency_ms")
+    private Float maxLatencyMs;
+
+    @JsonProperty("speed_ok")
+    private Boolean speedOk;
+
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/StabilityEvidence.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/StabilityEvidence.java
@@ -1,0 +1,25 @@
+package com.deeptruth.deeptruth.base.dto.deepfake;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StabilityEvidence {
+    @JsonProperty("temporal_delta_mean")
+    private Float temporalDeltaMean;
+
+    @JsonProperty("temporal_delta_std")
+    private Float temporalDeltaStd;
+
+    @JsonProperty("tta_mean")
+    private Float ttaMean;
+
+    @JsonProperty("tta_std")
+    private Float ttaStd;
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/Timeseries.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/Timeseries.java
@@ -1,0 +1,20 @@
+package com.deeptruth.deeptruth.base.dto.deepfake;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Timeseries {
+    @JsonProperty("per_frame_conf")
+    private List<Float> perFrameConf;
+    private Float vmin; // 0.0
+    private Float vmax; // 1.0
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/policy/BulletPolicyRegistry.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/policy/BulletPolicyRegistry.java
@@ -1,0 +1,46 @@
+package com.deeptruth.deeptruth.base.policy;
+
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class BulletPolicyRegistry {
+    /** 안정성 밴드 정의 (good/warn/bad 각 [min,max], max==NaN이면 상한 없음) */
+    public Map<String, float[][]> stabilityPolicy(boolean isFake) {
+        Map<String, float[][]> m = new HashMap<>();
+
+        m.put("temporal_mean", bands(0.0f, 0.03f, 0.03f, 0.06f, 0.06f, Float.NaN));
+        m.put("temporal_std",  bands(0.0f, 0.02f, 0.02f, 0.05f, 0.05f, Float.NaN));
+        m.put("tta_std",       bands(0.0f, 0.03f, 0.03f, 0.05f, 0.05f, Float.NaN));
+
+        if (isFake) {
+            m.put("tta_mean", bands(0.6f, Float.NaN, 0.4f, 0.6f, 0.0f, 0.4f));
+        } else {
+            m.put("tta_mean", bands(0.0f, 0.4f, 0.4f, 0.6f, 0.6f, Float.NaN));
+        }
+        return m;
+    }
+
+    /** 속도 밴드 정의 (SLA 반영) */
+    public Map<String, float[][]> speedPolicy(float targetFps, float maxLatencyMs) {
+        Map<String, float[][]> m = new HashMap<>();
+        m.put("fps", bands(targetFps, Float.NaN, 0.5f * targetFps, targetFps, 0.0f, 0.5f * targetFps));
+        m.put("lat", bands(0.0f, maxLatencyMs, maxLatencyMs, 2.0f * maxLatencyMs, 2.0f * maxLatencyMs, Float.NaN));
+        return m;
+    }
+
+    /** helper: good/warn/bad 3구간 */
+    private static float[][] bands(float gMin, float gMax, float wMin, float wMax, float bMin, float bMax) {
+        return new float[][]{
+                new float[]{gMin, norm(gMax)},
+                new float[]{wMin, norm(wMax)},
+                new float[]{bMin, norm(bMax)}
+        };
+    }
+
+    private static float norm(float v) {
+        return Float.isNaN(v) ? Float.NaN : v;
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/DeepfakeDetection.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/entity/DeepfakeDetection.java
@@ -3,6 +3,7 @@ package com.deeptruth.deeptruth.entity;
 import com.deeptruth.deeptruth.base.Enum.DeepfakeDetector;
 import com.deeptruth.deeptruth.base.Enum.DeepfakeMode;
 import com.deeptruth.deeptruth.base.Enum.DeepfakeResult;
+import com.deeptruth.deeptruth.base.dto.deepfake.Timeseries;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -24,47 +25,48 @@ public class DeepfakeDetection {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(length = 255)
-    private String filePath;
+    @Column(length = 255) private String filePath;
+    @Enumerated(EnumType.STRING) @Column(nullable = false) private DeepfakeResult result;
+    @Column(length = 64) private String taskId;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private DeepfakeResult result;
+    @Column private Float scoreWeighted;
+    @Column(name = "threshold_tau") private Float thresholdTau;
+    @Column private Float frameVoteRatio;
 
-    @Column
-    private Float averageConfidence;
+    @Column private Float averageConfidence;
+    @Column private Float medianConfidence;
+    @Column private Float maxConfidence;
+    @Column private Float varianceConfidence;
 
-    @Column
-    private Float maxConfidence;
+    @Column private Integer framesProcessed;
+    @Column private Float processingTimeSec;
+
+    @Column private Float fpsProcessed;
+    @Column private Float msPerSample;
+    @Column private Float targetFpsUsed;
+    @Column private Float maxLatencyMsUsed;
+    @Column private Boolean speedOk;
+
+    @Column private Float temporalDeltaMean;
+    @Column private Float temporalDeltaStd;
+    @Column private Float ttaMean;
+    @Column private Float ttaStd;
+
+    @Lob @Column(columnDefinition = "TEXT") private String timeseriesJson;
+
+    @Column private Float speedScore;
+    @Column private Float stabilityScore;
+
+    @Enumerated(EnumType.STRING) @Column private DeepfakeMode mode;
+    @Enumerated(EnumType.STRING) @Column private DeepfakeDetector detector;
+    @Column private Boolean useTta;
+    @Column private Boolean useIllum;
+    @Column private Integer smoothWindow;
+    @Column private Integer minFace;
+    @Column private Integer sampleCount;
 
     @Column(nullable=false, updatable = false)
     private LocalDateTime createdAt;
-
-    @Enumerated(EnumType.STRING)
-    @Column
-    private DeepfakeMode mode;
-
-    @Column
-    private Boolean useTta;
-
-    @Column
-    private Boolean useIllum;
-
-    @Enumerated(EnumType.STRING)
-    @Column
-    private DeepfakeDetector detector;
-
-    @Column
-    private Integer smoothWindow;
-
-    @Column
-    private Integer minFace;
-
-    @Column
-    private Integer sampleCount;
-
-    @Column
-    private String taskId;
 
     @PrePersist
     protected void onCreate() {

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
@@ -3,7 +3,9 @@ package com.deeptruth.deeptruth.service;
 import com.deeptruth.deeptruth.base.Enum.DeepfakeDetector;
 import com.deeptruth.deeptruth.base.Enum.DeepfakeMode;
 import com.deeptruth.deeptruth.base.Enum.DeepfakeResult;
+import com.deeptruth.deeptruth.base.dto.deepfake.BulletDTO;
 import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionDTO;
+import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionListDTO;
 import com.deeptruth.deeptruth.base.dto.deepfake.FlaskResponseDTO;
 import com.deeptruth.deeptruth.base.exception.*;
 import com.deeptruth.deeptruth.entity.DeepfakeDetection;
@@ -12,18 +14,21 @@ import com.deeptruth.deeptruth.repository.DeepfakeDetectionRepository;
 import com.deeptruth.deeptruth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import net.minidev.json.JSONUtil;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.Base64;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -32,45 +37,64 @@ import java.util.stream.Collectors;
 public class DeepfakeDetectionService {
 
     private final DeepfakeDetectionRepository deepfakeDetectionRepository;
-
     private final UserRepository userRepository;
-
     private final AmazonS3Service amazonS3Service;
+    private final DeepfakeViewAssembler assembler;
+    private final WebClient webClient;
+    @Value("${flask.deepfakeServer.url}")
+    private String flaskServerUrl;
 
-    public DeepfakeDetectionDTO createDetection(Long userId, FlaskResponseDTO dto){
+    public DeepfakeDetectionDTO createDetection(Long userId,
+                                                MultipartFile file,
+                                                Map<String, String> form){
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(userId));
 
-        if (dto == null) throw new InvalidDetectionResponseException("response is null");
-        if (dto.getResult() == null) throw new InvalidDetectionResponseException("result is null");
-        if (dto.getImageUrl() == null || dto.getImageUrl().isBlank())
-            throw new InvalidDetectionResponseException("imageUrl is blank");
-        if (dto.getAverageConfidence() != null &&
-                (dto.getAverageConfidence() < 0 || dto.getAverageConfidence() > 1))
-            throw new InvalidDetectionResponseException("averageConfidence out of [0,1]");
-        if (dto.getMaxConfidence() != null &&
-                (dto.getMaxConfidence() < 0 || dto.getMaxConfidence() > 1))
-            throw new InvalidDetectionResponseException("maxConfidence out of [0,1]");
+        String taskId = form.getOrDefault("taskId", UUID.randomUUID().toString());
 
+        MultipartBodyBuilder mb = new MultipartBodyBuilder();
+        mb.part("file", file.getResource())
+                .filename(file.getOriginalFilename() != null ? file.getOriginalFilename() : "upload.mp4")
+                .contentType(file.getContentType() != null ? MediaType.parseMediaType(file.getContentType())
+                        : MediaType.APPLICATION_OCTET_STREAM);
 
-        DeepfakeDetection detection = DeepfakeDetection.builder()
-                .user(user)
-                .filePath(dto.getImageUrl())
-                .result(dto.getResult())
-                .averageConfidence(dto.getAverageConfidence())
-                .maxConfidence(dto.getMaxConfidence())
-                .mode(DeepfakeMode.valueOf(dto.getMode().toUpperCase()))
-                .useTta(dto.getUseTta())
-                .useIllum(dto.getUseIllum())
-                .detector(DeepfakeDetector.valueOf(dto.getDetector().toUpperCase()))
-                .smoothWindow(dto.getSmoothWindow())
-                .minFace(dto.getMinFace())
-                .sampleCount(dto.getSampleCount())
-                .taskId(dto.getTaskId())
-                .build();
+        passThrough(mb, "taskId", taskId);
+        passThrough(mb, "mode", form.get("mode"));
+        passThrough(mb, "detector", form.get("detector"));
+        passThrough(mb, "use_tta", form.get("use_tta"));
+        passThrough(mb, "use_illum", form.get("use_illum"));
+        passThrough(mb, "min_face", form.get("min_face"));
+        passThrough(mb, "sample_count", form.get("sample_count"));
+        passThrough(mb, "smooth_window", form.get("smooth_window"));
+//        passThrough(mb, "target_fps", form.get("target_fps"));
+//        passThrough(mb, "max_latency_ms", form.get("max_latency_ms"));
 
-        deepfakeDetectionRepository.save(detection);
-        return DeepfakeDetectionDTO.fromEntity(detection);
+        FlaskResponseDTO flaskResult = webClient.post()
+                .uri(flaskServerUrl + "/predict")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(mb.build()))
+                .retrieve()
+                .bodyToMono(FlaskResponseDTO.class)
+                .block();
+
+        if (flaskResult == null) {
+            throw new ExternalServiceException("Flask response is null");
+        }
+
+        String base64Image = flaskResult.getBase64Url();
+
+        if (base64Image != null && !base64Image.isEmpty()) {
+            flaskResult.setImageUrl(uploadBase64ImageToS3(base64Image, user.getUserId()));
+        }
+
+        DeepfakeDetection entity = mapToEntity(user, flaskResult);
+        List<BulletDTO> stability = assembler.makeStabilityBullets(entity);
+        List<BulletDTO> speed     = assembler.makeSpeedBullets(entity);
+        entity.setStabilityScore(DeepfakeViewAssembler.meanScore(stability));
+        entity.setSpeedScore(DeepfakeViewAssembler.meanScore(speed));
+        deepfakeDetectionRepository.save(entity);
+
+        return DeepfakeDetectionDTO.fromEntity(entity,stability, speed);
     }
 
     public String uploadBase64ImageToS3(String base64Image, Long userId) {
@@ -90,21 +114,101 @@ public class DeepfakeDetectionService {
         }
     }
 
-    public Page<DeepfakeDetectionDTO> getAllResult(Long userId, Pageable pageable){
+    private static void passThrough(MultipartBodyBuilder mb, String key, String val) {
+        if (val != null) {
+            mb.part(key, val, MediaType.TEXT_PLAIN);
+        }
+    }
+
+    private DeepfakeDetection mapToEntity(User user, FlaskResponseDTO flaskResponseDTO) {
+        DeepfakeDetection detection = new DeepfakeDetection();
+        detection.setUser(user);
+        detection.setTaskId(flaskResponseDTO.getTaskId());
+        detection.setFilePath(flaskResponseDTO.getImageUrl());
+        detection.setResult(flaskResponseDTO.getResult());
+
+        // 판정/점수
+        detection.setScoreWeighted(flaskResponseDTO.getScoreWeighted());
+        detection.setThresholdTau(flaskResponseDTO.getThresholdTau());
+        detection.setFrameVoteRatio(flaskResponseDTO.getFrameVoteRatio());
+
+        // 통계
+        detection.setAverageConfidence(flaskResponseDTO.getAverageConfidence());
+        detection.setMedianConfidence(flaskResponseDTO.getMedianConfidence());
+        detection.setMaxConfidence(flaskResponseDTO.getMaxConfidence());
+        detection.setVarianceConfidence(flaskResponseDTO.getVarianceConfidence());
+
+        // 처리량/시간
+        detection.setFramesProcessed(flaskResponseDTO.getFramesProcessed());
+        detection.setProcessingTimeSec(flaskResponseDTO.getProcessingTimeSec());
+
+        // 속도(SLA 에코)
+        if (flaskResponseDTO.getSpeed() != null) {
+            detection.setMsPerSample(flaskResponseDTO.getSpeed().getMsPerSample());
+            detection.setTargetFpsUsed(flaskResponseDTO.getSpeed().getTargetFps());
+            detection.setMaxLatencyMsUsed(flaskResponseDTO.getSpeed().getMaxLatencyMs());
+            detection.setSpeedOk(flaskResponseDTO.getSpeed().getSpeedOk());
+            detection.setFpsProcessed(flaskResponseDTO.getSpeed().getFpsProcessed());
+        }
+
+        // 안정성 원시
+        if (flaskResponseDTO.getStabilityEvidence() != null) {
+            detection.setTemporalDeltaMean(flaskResponseDTO.getStabilityEvidence().getTemporalDeltaMean());
+            detection.setTemporalDeltaStd(flaskResponseDTO.getStabilityEvidence().getTemporalDeltaStd());
+            detection.setTtaMean(flaskResponseDTO.getStabilityEvidence().getTtaMean());
+            detection.setTtaStd(flaskResponseDTO.getStabilityEvidence().getTtaStd());
+        }
+
+        // 실행 환경/프로비넌스
+        if (flaskResponseDTO.getMode() != null) detection.setMode(DeepfakeMode.valueOf(flaskResponseDTO.getMode().toUpperCase()));
+        if (flaskResponseDTO.getDetector() != null) detection.setDetector(DeepfakeDetector.valueOf(flaskResponseDTO.getDetector().toUpperCase()));
+        detection.setUseTta(flaskResponseDTO.getUseTta());
+        detection.setUseIllum(flaskResponseDTO.getUseIllum());
+        detection.setMinFace(flaskResponseDTO.getMinFace());
+        detection.setSampleCount(flaskResponseDTO.getSampleCount());
+        detection.setSmoothWindow(flaskResponseDTO.getSmoothWindow());
+
+        // 히트맵
+        if (flaskResponseDTO.getTimeseries() != null && flaskResponseDTO.getTimeseries().getPerFrameConf() != null) {
+            String json = "{\"per_frame_conf\":" + toJsonArray(flaskResponseDTO.getTimeseries().getPerFrameConf())
+                    + ",\"vmin\":" + numOrNull(flaskResponseDTO.getTimeseries().getVmin())
+                    + ",\"vmax\":" + numOrNull(flaskResponseDTO.getTimeseries().getVmax()) + "}";
+            detection.setTimeseriesJson(json);
+        }
+
+        return detection;
+    }
+
+    private static String toJsonArray(List<Float> list) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i=0;i<list.size();i++){
+            if (i>0) sb.append(',');
+            Float v = list.get(i);
+            sb.append(v==null?"null":String.valueOf(v));
+        }
+        sb.append(']');
+        return sb.toString();
+    }
+
+    private static String numOrNull(Number n){ return n==null?"null":String.valueOf(n); }
+
+    public Page<DeepfakeDetectionListDTO> getAllResult(Long userId, Pageable pageable){
         userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
         return deepfakeDetectionRepository.findByUser_UserId(userId, pageable)
-                .map(DeepfakeDetectionDTO::fromEntity);
+                .map(DeepfakeDetectionListDTO::fromEntity);
     }
 
     public DeepfakeDetectionDTO getSingleResult(Long userId, Long id) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(userId));
 
-        DeepfakeDetection detection = deepfakeDetectionRepository
+        DeepfakeDetection entity = deepfakeDetectionRepository
                 .findByDeepfakeDetectionIdAndUser(id, user)
                 .orElseThrow(() -> new DetectionNotFoundException(id, userId));
 
-        return DeepfakeDetectionDTO.fromEntity(detection);
+        List<BulletDTO> stability = assembler.makeStabilityBullets(entity);
+        List<BulletDTO> speed     = assembler.makeSpeedBullets(entity);
+        return DeepfakeDetectionDTO.fromEntity(entity, stability, speed);
     }
 
     public void deleteResult(Long userId, Long id){

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeViewAssembler.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeViewAssembler.java
@@ -1,0 +1,114 @@
+package com.deeptruth.deeptruth.service;
+import com.deeptruth.deeptruth.base.Enum.DeepfakeResult;
+import com.deeptruth.deeptruth.base.dto.deepfake.BulletDTO;
+import com.deeptruth.deeptruth.base.policy.BulletPolicyRegistry;
+import com.deeptruth.deeptruth.entity.DeepfakeDetection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class DeepfakeViewAssembler {
+
+    private final BulletPolicyRegistry policy;
+
+    /** 조회용: 안정성 불릿 */
+    public List<BulletDTO> makeStabilityBullets(DeepfakeDetection e) {
+        boolean isFake = e.getResult() == DeepfakeResult.FAKE;
+        Map<String, float[][]> bands = policy.stabilityPolicy(isFake);
+
+        List<BulletDTO> out = new ArrayList<>();
+        out.add(build("temporal_delta_mean","Δ Mean (↓)", F(e.getTemporalDeltaMean()), bands.get("temporal_mean"),"lower", null));
+        out.add(build("temporal_delta_std", "Δ Std (↓)",  F(e.getTemporalDeltaStd()),  bands.get("temporal_std"), "lower", null));
+        out.add(build("tta_std",            "TTA Std (↓)", F(e.getTtaStd()),          bands.get("tta_std"),      "lower", null));
+
+        String label = isFake ? "TTA Mean (FAKE↑)" : "TTA Mean (REAL↓)";
+        String dir   = isFake ? "higher" : "lower";
+        out.add(build("tta_mean", label, F(e.getTtaMean()), bands.get("tta_mean"), dir, null));
+        return out;
+    }
+
+    /** 조회용: 속도 불릿 (엔티티에 저장된 SLA로 재계산) */
+    public List<BulletDTO> makeSpeedBullets(DeepfakeDetection e) {
+        float targetFps = Optional.ofNullable(e.getTargetFpsUsed()).map(Number::floatValue).orElse(1.0f);
+        float maxLatMs  = Optional.ofNullable(e.getMaxLatencyMsUsed()).map(Number::floatValue).orElse(2000.0f);
+
+        Map<String, float[][]> bands = policy.speedPolicy(targetFps, maxLatMs);
+
+        List<BulletDTO> out = new ArrayList<>();
+        out.add(build("fps_processed", "Throughput (fps ↑)", F(e.getFpsProcessed()), bands.get("fps"), "higher", "fps"));
+        out.add(build("ms_per_sample", "Latency (ms/sample ↓)", F(e.getMsPerSample()), bands.get("lat"), "lower", "ms"));
+        return out;
+    }
+
+    /** 여러 불릿 평균 점수 → 0~100 */
+    public static Float meanScore(List<BulletDTO> bullets) {
+        List<Float> scores = new ArrayList<>();
+        for (BulletDTO b : bullets) {
+            Float s = scoreFromBands(b.getValue(), toArr(b.getBands()), b.getDirection());
+            if (s != null) scores.add(s);
+        }
+        if (scores.isEmpty()) return null;
+        float sum = 0f;
+        for (Float s : scores) sum += s;
+        return (sum / scores.size()) * 100.0f;
+    }
+
+    /** 밴드 기반 점수 0~1 산출 (float) */
+    public static Float scoreFromBands(Float value, float[][] bands, String direction) {
+        if (value == null || bands == null) return null;
+        float[] good = bands[0], warn = bands[1]; // bad는 0점
+
+        if ("lower".equals(direction)) {
+            Float gMax = finite(good[1]);
+            Float wMax = finite(warn[1]);
+            if (gMax != null && value <= gMax) return 1.0f;
+            if (wMax != null && value <= wMax) {
+                float gHi = (gMax != null) ? gMax : warn[1];
+                float denom = Math.max(1e-9f, (wMax - gHi));
+                return (wMax - value) / denom;
+            }
+            return 0.0f;
+        } else { // "higher"
+            Float gMin = finite(good[0]);
+            Float wMin = finite(warn[0]);
+            if (gMin != null && value >= gMin) return 1.0f;
+            if (wMin != null && value >= wMin) {
+                float denom = Math.max(1e-9f, (gMin - wMin));
+                return (value - wMin) / denom;
+            }
+            return 0.0f;
+        }
+    }
+
+    private static BulletDTO build(String key, String label, Float value,
+                                   float[][] bandArr, String direction, String unit) {
+        Map<String, float[]> m = new LinkedHashMap<>();
+        if (bandArr != null) {
+            m.put("good", bandArr[0]);
+            m.put("warn", bandArr[1]);
+            m.put("bad",  bandArr[2]);
+        }
+        BulletDTO dto = new BulletDTO();
+        dto.setKey(key);
+        dto.setLabel(label);
+        dto.setValue(value);
+        dto.setBands(m);
+        dto.setDirection(direction);
+        dto.setUnit(unit);
+        return dto;
+    }
+
+    private static Float F(Number n) { return n == null ? null : n.floatValue(); }
+
+    private static float[][] toArr(Map<String, float[]> m) {
+        if (m == null) return null;
+        return new float[][]{ m.get("good"), m.get("warn"), m.get("bad") };
+    }
+
+    private static Float finite(float v) {
+        return Float.isNaN(v) ? null : v;
+    }
+}


### PR DESCRIPTION
## 📝 Summary
- 사용자에게 시각적으로 정확성 및 속도를 차트로 나타내기 위해 spring 에서 불릿/점수 재계산 후 프론트에 전달하는 구조로 정리했습니다.
- 히트맵은 timeseries(per_frame_conf) 값으로 프론트에서 그릴 수 있도록 했습니다.

## 💻 Describe your changes
### 1) 엔티티 확장 (DeepfakeDetection)
- 판정/점수: `scoreWeighted`, `thresholdTau`, `frameVoteRatio`
- 통계: `averageConfidence`, `medianConfidence`, `maxConfidence`, `varianceConfidence`
- 처리/속도: `framesProcessed`, `processingTimeSec`, `fpsProcessed`, `msPerSample`, `targetFpsUsed`, `maxLatencyMsUsed`, `speedOk`, `speedScore`
- 안정성: `stabilityScore`, `temporalDeltaMean`, `temporalDeltaStd`, `ttaMean, ttaStd`
- 실행 환경: `mode`, `detector`, `useTta`, `useIllum`, `smoothWindow`, `minFace`, `sampleCount`
- 부가: `filePath`(썸네일), `timeseriesJson`(히트맵용 데이터)
- 인덱스: `task_id`, `created_at`
<br/>

### 2) DTO/정책/어셈블러 (float 기반)
- ` FlaskResponseDTO`: Flask 응답 스키마 반영(stability_evidence, speed, timeseries, most_suspect_image 등)
- `BulletDTO`: 불릿 차트용 DTO (value: Float, bands: Map<String, Float[]>, 상한 없음은 null)
- `BulletPolicyRegistry`: 안정성/속도 밴드(good/warn/bad) 정책 정의
- ` DeepfakeViewAssembler`: 엔티티 → 불릿 생성 및 평균 점수(0~100) 산출
<br/>

### 3) 서비스/컨트롤러
- DeepfakeDetectionService
    - createDetection(userId, file, form): Flask /predict 호출 → Base64 썸네일 S3 업로드 → 엔티티 저장 → 불릿/점수 재계산 → DTO 반환
    - getAllResult(userId, pageable), getSingleResult(userId, id): 저장값 + 정책에 따른 불릿/점수 동적 계산 포함해 반환
- DeepfakeController
    - POST /api/deepfake (multipart)
    - GET /api/deepfake, GET /api/deepfake/{deepfakeId}
<br/>

#### 4) POST /api/deepfake API 요약
요청 (multipart)
필수: file
선택: taskId, mode(default|precision), detector(auto|dlib|dnn), use_tta, use_illum, min_face, sample_count, target_fps, max_latency_ms

##### 응답 예시
```json
{
    "status": 200,
    "success": true,
    "message": "딥페이크 탐지 결과 수신 성공",
    "data": {
        "id": 26,
        "taskId": "test-task",
        "filePath": "https://....jpg",
        "createdAt": "2025-09-04T16:00:06.6462529",
        "result": "FAKE",
        "scoreWeighted": 0.587,
        "thresholdTau": 0.5,
        "frameVoteRatio": 1.0,
        "averageConfidence": 0.5788,
        "maxConfidence": 0.6867,
        "medianConfidence": 0.5705,
        "varianceConfidence": 9.33E-4,
        "framesProcessed": 20,
        "processingTimeSec": 157.093,
        "fpsProcessed": 0.127,
        "msPerSample": 7854.6,
        "targetFpsUsed": 0.27,
        "maxLatencyMsUsed": 4000.0,
        "speedOk": false,
        "temporalDeltaMean": 0.022971,
        "temporalDeltaStd": 0.011405,
        "ttaMean": 0.686126,
        "ttaStd": 0.021149,
        "timeseriesJson": "{\"per_frame_conf\":[0.56829333,0.5896857,0.59154785,0.5586699,0.60798335,0.5756162,0.55556655,0.58327407,0.5727345,0.54399633,0.55871713,0.5634964,0.5370794,0.55711764,0.5680564,0.547018,0.58784163,0.61496276,0.6346359,0.66068417],\"vmin\":0.0,\"vmax\":1.0}",
        "speedScore": 1.8174987,
        "stabilityScore": 100.0,
        "mode": "PRECISION",
        "detector": "DNN",
        "useTta": true,
        "useIllum": true,
        "smoothWindow": 0,
        "minFace": 96,
        "sampleCount": 20,
        "stabilityBullets": [...],
        "speedBullets": [...]
    }
}
```

## #️⃣ Issue number and link
#42

## 💬 Message to the Reviewer
- 프론트는 stabilityBullets/speedBullets를 그대로 불릿 차트로 렌더하면 됩니다. (bands.good|warn|bad 범위와 direction 사용)
- 과거 기록도 정책 변경 즉시 재계산되어 반영됩니다
