### PR TITLE
Fix: 충돌 오류 해결 - GET /deepfake 반환형 수정

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionController.java
@@ -56,7 +56,7 @@ public class DeepfakeDetectionController {
     @GetMapping
     public ResponseEntity<ResponseDTO> getAllDetections(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                         @PageableDefault(size = 15, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable){
-        Page<DeepfakeDetectionDTO> result = deepfakeDetectionService.getAllResult(userDetails.getUserId(), pageable);
+        Page<DeepfakeDetectionListDTO> result = deepfakeDetectionService.getAllResult(userDetails.getUserId(), pageable);
 
         return ResponseEntity.ok(
                 ResponseDTO.success(200, "딥페이크 탐지 결과 전체 조회 성공", result)


### PR DESCRIPTION
## 📝 Summary
브랜치 충돌시 오류난 GET /deepfake 반환형 수정했습니다. 
 
## 💻 Describe your changes
#### 1) DeepfakeController 수정
`DeepfakeDetectionDTO `-> `DeepfakeDetectionListDTO`
`Page<DeepfakeDetectionListDTO> result = deepfakeDetectionService.getAllResult(userDetails.getUserId(), pageable);
`

## #️⃣ Issue number and link
#34 

## 💬 Message to the Reviewer