### PR TITLE
Feat: Deepfake 및 Watermark, S3 서비스에 관련된 전역 예외 처리 도입 

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/ArtifactNotFoundException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/ArtifactNotFoundException.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class ArtifactNotFoundException extends RuntimeException {
+    public ArtifactNotFoundException(String m){
+        super(m);
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/DataCorruptionException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/DataCorruptionException.java
@@ -1,0 +1,5 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class DataCorruptionException extends RuntimeException {
+    public DataCorruptionException(String message) { super(message); }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/DataMappingException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/DataMappingException.java
@@ -1,0 +1,6 @@
+package com.deeptruth.deeptruth.base.exception;
+
+// 필수 필드 누락/엔티티 변환 불가/데이터 불일치
+public class DataMappingException extends RuntimeException {
+    public DataMappingException(String message) { super(message); }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/FileEmptyException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/FileEmptyException.java
@@ -1,0 +1,5 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class FileEmptyException  extends RuntimeException {
+    public FileEmptyException() { super("업로드할 파일이 비어 있습니다."); }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/GlobalExceptionHandler.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/GlobalExceptionHandler.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
     // 400 - 잘못된 요청
     @ExceptionHandler({InvalidFileException.class, ImageDecodingException.class,
-            IllegalArgumentException.class})
+            IllegalArgumentException.class, FileEmptyException.class, InvalidFilenameException.class})
     public ResponseEntity<ResponseDTO> handleBadRequest(RuntimeException ex) {
         log.info("[400] {}", ex.getMessage());
         return ResponseEntity
@@ -61,6 +61,15 @@ public class GlobalExceptionHandler {
                 .body(ResponseDTO.fail(409, ex.getMessage()));
     }
 
+    // 415 Unsupported Media Type
+    @ExceptionHandler(UnsupportedMediaTypeException.class)
+    public ResponseEntity<ResponseDTO<Void>> handleUnsupported(UnsupportedMediaTypeException ex) {
+        log.info("[415] {}", ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+                .body(ResponseDTO.fail(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value(), ex.getMessage()));
+    }
+
     // 422 - 처리할 수 없는 엔티티 (유효성은 맞지만 비즈니스 규칙 위반)
     @ExceptionHandler({InvalidDetectionResponseException.class, InvalidWatermarkResponseException.class})
     public ResponseEntity<ResponseDTO> handleUnprocessableEntity(RuntimeException ex) {
@@ -71,7 +80,7 @@ public class GlobalExceptionHandler {
     }
 
     // 5xx - 서버/외부 연동 문제
-    @ExceptionHandler({StorageException.class, ExternalServiceException.class})
+    @ExceptionHandler({StorageException.class, ExternalServiceException.class, S3UploadFailedException.class})
     public ResponseEntity<ResponseDTO> handleServerError(RuntimeException ex) {
         log.error("[502] {}", ex.getMessage(), ex);
         return ResponseEntity

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/GlobalExceptionHandler.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/GlobalExceptionHandler.java
@@ -44,7 +44,7 @@ public class GlobalExceptionHandler {
     }
 
     // 404 - 리소스 없음
-    @ExceptionHandler({DetectionNotFoundException.class, WatermarkNotFoundException.class, NoiseNotFoundException.class})
+    @ExceptionHandler({DetectionNotFoundException.class, WatermarkNotFoundException.class, NoiseNotFoundException.class, ArtifactNotFoundException.class})
     public ResponseEntity<ResponseDTO> handleResourceNotFound(RuntimeException ex) {
         log.info("[404] {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
@@ -71,7 +71,7 @@ public class GlobalExceptionHandler {
     }
 
     // 422 - 처리할 수 없는 엔티티 (유효성은 맞지만 비즈니스 규칙 위반)
-    @ExceptionHandler({InvalidDetectionResponseException.class, InvalidWatermarkResponseException.class, DataCorruptionException.class, DataMappingException.class})
+    @ExceptionHandler({InvalidDetectionResponseException.class, InvalidWatermarkResponseException.class, DataCorruptionException.class, DataMappingException.class, SimilarityThresholdExceededException.class})
     public ResponseEntity<ResponseDTO> handleUnprocessableEntity(RuntimeException ex) {
         log.info("[422] {}", ex.getMessage());
         return ResponseEntity

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/GlobalExceptionHandler.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/GlobalExceptionHandler.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
     // 400 - 잘못된 요청
     @ExceptionHandler({InvalidFileException.class, ImageDecodingException.class,
-            IllegalArgumentException.class, FileEmptyException.class, InvalidFilenameException.class})
+            IllegalArgumentException.class, FileEmptyException.class, InvalidFilenameException.class, InvalidEnumValueException.class})
     public ResponseEntity<ResponseDTO> handleBadRequest(RuntimeException ex) {
         log.info("[400] {}", ex.getMessage());
         return ResponseEntity
@@ -71,7 +71,7 @@ public class GlobalExceptionHandler {
     }
 
     // 422 - 처리할 수 없는 엔티티 (유효성은 맞지만 비즈니스 규칙 위반)
-    @ExceptionHandler({InvalidDetectionResponseException.class, InvalidWatermarkResponseException.class})
+    @ExceptionHandler({InvalidDetectionResponseException.class, InvalidWatermarkResponseException.class, DataCorruptionException.class, DataMappingException.class})
     public ResponseEntity<ResponseDTO> handleUnprocessableEntity(RuntimeException ex) {
         log.info("[422] {}", ex.getMessage());
         return ResponseEntity

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/GlobalExceptionHandler.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/GlobalExceptionHandler.java
@@ -21,7 +21,7 @@ public class GlobalExceptionHandler {
     }
 
     // 401 - 인증 실패
-    @ExceptionHandler(UserNotFoundException.class)
+    @ExceptionHandler({UserNotFoundException.class, UnauthorizedException.class})
     public ResponseEntity<ResponseDTO> handleUserNotFoundException(RuntimeException ex) {
         log.info("[401] {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/InvalidEnumValueException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/InvalidEnumValueException.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class InvalidEnumValueException extends RuntimeException {
+    public InvalidEnumValueException(String field, String value) {
+        super("Invalid enum value for " + field + ": " + value);
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/InvalidFilenameException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/InvalidFilenameException.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class InvalidFilenameException extends RuntimeException {
+    public InvalidFilenameException(String filename) {
+        super("파일 이름이 유효하지 않습니다: " + filename);
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/S3UploadFailedException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/S3UploadFailedException.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class S3UploadFailedException extends RuntimeException {
+    public S3UploadFailedException(String key, Throwable cause) {
+        super("S3 업로드에 실패했습니다. key=" + key, cause);
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/SimilarityThresholdExceededException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/SimilarityThresholdExceededException.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class SimilarityThresholdExceededException extends RuntimeException {
+    public SimilarityThresholdExceededException(int dist, int th) {
+        super("유사도가 임계값을 초과했습니다. dist=" + dist + ", threshold=" + th);
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/UnauthorizedException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class UnauthorizedException  extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/UnsupportedMediaTypeException.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/exception/UnsupportedMediaTypeException.java
@@ -1,0 +1,7 @@
+package com.deeptruth.deeptruth.base.exception;
+
+public class UnsupportedMediaTypeException extends RuntimeException {
+    public UnsupportedMediaTypeException(String contentType) {
+        super("지원하지 않는 콘텐츠 타입입니다: " + contentType);
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionController.java
@@ -2,32 +2,20 @@ package com.deeptruth.deeptruth.controller;
 
 import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionDTO;
 import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionListDTO;
-import com.deeptruth.deeptruth.base.dto.deepfake.FlaskResponseDTO;
 import com.deeptruth.deeptruth.base.dto.response.ResponseDTO;
 import com.deeptruth.deeptruth.config.CustomUserDetails;
-import com.deeptruth.deeptruth.entity.User;
 import com.deeptruth.deeptruth.service.DeepfakeDetectionService;
-import com.deeptruth.deeptruth.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ByteArrayResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.reactive.function.BodyInserters;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -42,22 +30,15 @@ public class DeepfakeDetectionController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestPart("file")MultipartFile multipartFile,
             @RequestParam(required = false) Map<String, String> params){
-        try {
             Map<String, String> form = (params == null) ? new HashMap<>() : params;
             DeepfakeDetectionDTO dto = deepfakeDetectionService.createDetection(userDetails.getUserId(), multipartFile, form);
             return ResponseEntity.ok(ResponseDTO.success(200, "딥페이크 탐지 결과 수신 성공", dto));
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            return ResponseEntity.status(500).body(ResponseDTO.fail(500, "서버 오류: " + e.getMessage()));
-        }
     }
 
     @GetMapping
     public ResponseEntity<ResponseDTO> getAllDetections(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                         @PageableDefault(size = 15, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable){
         Page<DeepfakeDetectionListDTO> result = deepfakeDetectionService.getAllResult(userDetails.getUserId(), pageable);
-
         return ResponseEntity.ok(
                 ResponseDTO.success(200, "딥페이크 탐지 결과 전체 조회 성공", result)
         );

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/WatermarkController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/WatermarkController.java
@@ -2,10 +2,7 @@ package com.deeptruth.deeptruth.controller;
 
 import com.deeptruth.deeptruth.base.dto.response.ResponseDTO;
 import com.deeptruth.deeptruth.base.dto.watermark.InsertResultDTO;
-import com.deeptruth.deeptruth.base.dto.watermark.WatermarkDTO;
-import com.deeptruth.deeptruth.base.dto.watermark.WatermarkFlaskResponseDTO;
 import com.deeptruth.deeptruth.config.CustomUserDetails;
-import com.deeptruth.deeptruth.entity.User;
 import com.deeptruth.deeptruth.service.UserService;
 import com.deeptruth.deeptruth.service.WatermarkService;
 import lombok.RequiredArgsConstructor;
@@ -13,19 +10,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,27 +28,12 @@ public class WatermarkController {
 
     @PostMapping
     public ResponseEntity<ResponseDTO> insertWatermark(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestPart("file") MultipartFile multipartFile, @RequestPart String message, @RequestParam(required = false) String taskId){
-        try {
-            if (userDetails == null) {
-                return ResponseEntity.status(401)
-                        .body(ResponseDTO.fail(401, "인증이 필요합니다."));
-            }
-
-            InsertResultDTO result = waterMarkService.insert(userDetails.getUserId(), multipartFile, message, taskId);
-            return ResponseEntity.ok(ResponseDTO.success(200, "워터마크 삽입 성공", result));
-
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(ResponseDTO.fail(400, e.getMessage()));
-        } catch (Exception e) {
-            e.printStackTrace();
-            return ResponseEntity.status(500).body(ResponseDTO.fail(500, "서버 오류: " + e.getMessage()));
-        }
+        InsertResultDTO result = waterMarkService.insert(userDetails.getUserId(), multipartFile, message, taskId);
+        return ResponseEntity.ok(ResponseDTO.success(200, "워터마크 삽입 성공", result));
     }
 
     @GetMapping
     public ResponseEntity<ResponseDTO> getAllWatermarks(@AuthenticationPrincipal CustomUserDetails userDetails, @PageableDefault(size = 15, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable){
-
-
         Page<InsertResultDTO> result = waterMarkService.getAllResult(userDetails.getUserId(), pageable);
         return ResponseEntity.ok(
                 ResponseDTO.success(200, "워터마크 삽입 기록 전체 조회 성공", result)
@@ -69,14 +43,12 @@ public class WatermarkController {
 
     @GetMapping("/{id}")
     public ResponseEntity<ResponseDTO> getWatermark(@PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails){
-
         InsertResultDTO result = waterMarkService.getSingleResult(userDetails.getUserId(), id);
         return ResponseEntity.ok(ResponseDTO.success(200, "워터마크 삽입 기록 조회 성공", result));
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<ResponseDTO> deleteWatermark(@PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails){
-
         waterMarkService.deleteWatermark(userDetails.getUserId(), id);
         return ResponseEntity.ok(
                 ResponseDTO.success(200, "워터마크 삽입 기록 삭제 성공", null)

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/WatermarkDetectionController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/WatermarkDetectionController.java
@@ -23,19 +23,7 @@ public class WatermarkDetectionController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestPart("file") MultipartFile file,
             @RequestParam(required = false) String taskId) {
-        if (userDetails == null) {
-            return ResponseEntity.status(401)
-                    .body(ResponseDTO.fail(401, "인증이 필요합니다."));
-        }
-        try {
             DetectResultDTO result = detectionService.detect(userDetails.getUserId(), file, taskId);
             return ResponseEntity.ok(ResponseDTO.success(200, "워터마크 탐지 성공", result));
-        } catch (IllegalStateException ex) {
-            return ResponseEntity.status(404)
-                    .body(ResponseDTO.fail(404, ex.getMessage()));
-        } catch (Exception e) {
-            return ResponseEntity.status(502)
-                    .body(ResponseDTO.fail(502, "서버 오류: " + e.getMessage()));
-        }
     }
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
@@ -2,7 +2,6 @@ package com.deeptruth.deeptruth.service;
 
 import com.deeptruth.deeptruth.base.Enum.DeepfakeDetector;
 import com.deeptruth.deeptruth.base.Enum.DeepfakeMode;
-import com.deeptruth.deeptruth.base.Enum.DeepfakeResult;
 import com.deeptruth.deeptruth.base.dto.deepfake.BulletDTO;
 import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionDTO;
 import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionListDTO;
@@ -13,9 +12,7 @@ import com.deeptruth.deeptruth.entity.User;
 import com.deeptruth.deeptruth.repository.DeepfakeDetectionRepository;
 import com.deeptruth.deeptruth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import net.minidev.json.JSONUtil;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ByteArrayResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
@@ -29,7 +26,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
@@ -49,6 +49,15 @@ public class DeepfakeDetectionService {
                                                 Map<String, String> form){
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(userId));
+        if (file == null || file.isEmpty()) throw new FileEmptyException();
+
+        String contentType = file.getContentType();
+        if (contentType == null) contentType = MediaType.APPLICATION_OCTET_STREAM_VALUE;
+
+        if (!(contentType.startsWith("image/") || contentType.startsWith("video/")
+                || MediaType.APPLICATION_OCTET_STREAM_VALUE.equals(contentType))) {
+            throw new UnsupportedMediaTypeException(contentType);
+        }
 
         String taskId = form.getOrDefault("taskId", UUID.randomUUID().toString());
 
@@ -69,13 +78,25 @@ public class DeepfakeDetectionService {
 //        passThrough(mb, "target_fps", form.get("target_fps"));
 //        passThrough(mb, "max_latency_ms", form.get("max_latency_ms"));
 
-        FlaskResponseDTO flaskResult = webClient.post()
-                .uri(flaskServerUrl + "/predict")
-                .contentType(MediaType.MULTIPART_FORM_DATA)
-                .body(BodyInserters.fromMultipartData(mb.build()))
-                .retrieve()
-                .bodyToMono(FlaskResponseDTO.class)
-                .block();
+        FlaskResponseDTO flaskResult;
+        try {
+            flaskResult = webClient.post()
+                    .uri(flaskServerUrl + "/predict")
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(BodyInserters.fromMultipartData(mb.build()))
+                    .retrieve()
+                    .bodyToMono(FlaskResponseDTO.class)
+                    .block();
+        } catch (org.springframework.web.reactive.function.client.WebClientResponseException e) {
+            // HTTP 응답은 왔지만 4xx/5xx
+            throw new ExternalServiceException("Flask HTTP error: " + e.getRawStatusCode() + " " + e.getResponseBodyAsString());
+        } catch (org.springframework.web.reactive.function.client.WebClientRequestException e) {
+            // 연결 실패/타임아웃 등
+            throw new ExternalServiceException("Flask request failed: " + e.getMessage());
+        }  catch (Exception e) {
+            throw new ExternalServiceException("Flask invocation failed");
+        }
+
 
         if (flaskResult == null) {
             throw new ExternalServiceException("Flask response is null");
@@ -90,6 +111,9 @@ public class DeepfakeDetectionService {
         DeepfakeDetection entity = mapToEntity(user, flaskResult);
         List<BulletDTO> stability = assembler.makeStabilityBullets(entity);
         List<BulletDTO> speed     = assembler.makeSpeedBullets(entity);
+        if (stability == null || speed == null) {
+            throw new DataMappingException("bullet assembling failed");
+        }
         entity.setStabilityScore(DeepfakeViewAssembler.meanScore(stability));
         entity.setSpeedScore(DeepfakeViewAssembler.meanScore(speed));
         deepfakeDetectionRepository.save(entity);
@@ -121,6 +145,10 @@ public class DeepfakeDetectionService {
     }
 
     private DeepfakeDetection mapToEntity(User user, FlaskResponseDTO flaskResponseDTO) {
+        if (flaskResponseDTO == null) throw new DataMappingException("flask response is null");
+        if (flaskResponseDTO.getTaskId() == null || flaskResponseDTO.getImageUrl() == null || flaskResponseDTO.getResult() == null) {
+            throw new DataMappingException("required fields missing in flask response");
+        }
         DeepfakeDetection detection = new DeepfakeDetection();
         detection.setUser(user);
         detection.setTaskId(flaskResponseDTO.getTaskId());
@@ -160,8 +188,20 @@ public class DeepfakeDetectionService {
         }
 
         // 실행 환경/프로비넌스
-        if (flaskResponseDTO.getMode() != null) detection.setMode(DeepfakeMode.valueOf(flaskResponseDTO.getMode().toUpperCase()));
-        if (flaskResponseDTO.getDetector() != null) detection.setDetector(DeepfakeDetector.valueOf(flaskResponseDTO.getDetector().toUpperCase()));
+        if (flaskResponseDTO.getMode() != null) {
+            try {
+                detection.setMode(DeepfakeMode.valueOf(flaskResponseDTO.getMode().toUpperCase()));
+            } catch (IllegalArgumentException ex) {
+                throw new InvalidEnumValueException("mode", flaskResponseDTO.getMode());
+            }
+        }
+        if (flaskResponseDTO.getDetector() != null) {
+            try {
+                detection.setDetector(DeepfakeDetector.valueOf(flaskResponseDTO.getDetector().toUpperCase()));
+            } catch (IllegalArgumentException ex) {
+                throw new InvalidEnumValueException("detector", flaskResponseDTO.getDetector());
+            }
+        }
         detection.setUseTta(flaskResponseDTO.getUseTta());
         detection.setUseIllum(flaskResponseDTO.getUseIllum());
         detection.setMinFace(flaskResponseDTO.getMinFace());
@@ -194,6 +234,7 @@ public class DeepfakeDetectionService {
 
     public Page<DeepfakeDetectionListDTO> getAllResult(Long userId, Pageable pageable){
         userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
+        if (pageable == null) throw new DataMappingException("pageable is null");
         return deepfakeDetectionRepository.findByUser_UserId(userId, pageable)
                 .map(DeepfakeDetectionListDTO::fromEntity);
     }
@@ -208,12 +249,22 @@ public class DeepfakeDetectionService {
 
         List<BulletDTO> stability = assembler.makeStabilityBullets(entity);
         List<BulletDTO> speed     = assembler.makeSpeedBullets(entity);
+
+        if (stability == null || speed == null) {
+            throw new DataCorruptionException("Bullet assembling failed: null list");
+        }
+
         return DeepfakeDetectionDTO.fromEntity(entity, stability, speed);
     }
 
     public void deleteResult(Long userId, Long id){
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(userId));
+
+        DeepfakeDetection entity = deepfakeDetectionRepository
+                .findByDeepfakeDetectionIdAndUser(id, user)
+                .orElseThrow(() -> new DetectionNotFoundException(id, userId));
+
         int deleted = deepfakeDetectionRepository.deleteByDeepfakeDetectionIdAndUser(id, user);
         if (deleted == 0) {
             throw new DetectionNotFoundException(id, userId);

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkService.java
@@ -44,7 +44,7 @@ public class WatermarkService {
 
     public InsertResultDTO insert(Long userId, MultipartFile file, String message, String taskId) {
         // 1) 유효성
-        if (message == null) {
+        if (message == null | message.isBlank()) {
             throw new IllegalArgumentException("message는 null일 수 없습니다.");
         }
         if (message.length() > 4) {


### PR DESCRIPTION
## 📝 Summary
딥페이크와 워터마크, S3 업로드와 관련된 전역 예외 처리(GlobalExceptionHandler)를 도입하여 서비스 및 컨트롤러 전반에서 발생하는 예외를 일관된 `ResponseDTO` 포맷으로 응답하도록 개선했습니다.  예외 상황별로 명확한 HTTP 상태 코드와 메시지를 내려 클라이언트 단 처리와 디버깅 편의성을 높였습니다.

## 💻 Describe your changes
- 커스텀 예외 클래스 정의 (`RuntimeException` 상속)
  - `FileEmptyException`, `InvalidFilenameException`, `InvalidEnumValueException` (400)
  - `UnsupportedMediaTypeException` (415)
  - `DataCorruptionException`, `DataMappingException`, `SimilarityThresholdExceededException` (422)
  - `S3UploadFailedException` (502)
  - `UnauthorizedException` (401)
  - `ArtifactNotFoundException`(404)
- 서비스 코드에서 `RuntimeException` 대신 의미 있는 커스텀 예외 사용
  - AmazonS3Service, DeepfakeDetectionService, WatermarkService, WatermarkDetectionService 등 적용
- 컨트롤러에서 불필요한 try/catch 제거 → 전역 핸들러가 처리하도록 위임

## #️⃣ Issue number and link
#65 

## 💬 Message to the Reviewer
- 현재는 `ResponseDTO`를 성공/실패 모두에 재사용 중인데, 필요하다면 `ErrorResponseDTO`를 별도로 두는 것도 고려할 수 있습니다.  
- `UnauthorizedException` 을 상태코드 `UNAUTHORIZED`(401)로 매핑해놓았는데 합리적인지 검토 부탁드립니다. 
