### PR TITLE
Fix: DeepfakeDetectionListDTO의 fromEntity 수정

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/DeepfakeDetectionListDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/deepfake/DeepfakeDetectionListDTO.java
@@ -24,6 +24,7 @@ public class DeepfakeDetectionListDTO {
                 .taskId(entity.getTaskId())
                 .filePath(entity.getFilePath())
                 .result(entity.getResult())
+                .createdAt(entity.getCreatedAt())
                 .deepfakeMode(entity.getMode())
                 .build();
     }


### PR DESCRIPTION
DeepfakeDetectionListDTO의 fromEntity에서 createAt 생성 부분에 누락된 부분을 수정했습니다. 
