### PR TITLE
Test: 워터마크 서비스, 컨트롤러 테스트 수정 및 WithMockCustomUser 생성

### DIFF
--- a/deeptruth/build.gradle
+++ b/deeptruth/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'org.springframework.boot:spring-boot-starter'
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/WatermarkControllerTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/controller/WatermarkControllerTest.java
@@ -1,88 +1,168 @@
 package com.deeptruth.deeptruth.controller;
 
-import com.deeptruth.deeptruth.base.dto.watermark.WatermarkDTO;
+import com.deeptruth.deeptruth.base.dto.watermark.InsertResultDTO;
+import com.deeptruth.deeptruth.config.JwtAuthenticationFilter;
+import com.deeptruth.deeptruth.config.SecurityConfig;
+import com.deeptruth.deeptruth.service.UserService;
 import com.deeptruth.deeptruth.service.WatermarkService;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.deeptruth.deeptruth.testsecurity.WithMockCustomUser;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.reactive.function.client.WebClient;
 
+
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(controllers = WatermarkController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(
+        controllers = WatermarkController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                        SecurityConfig.class,        // 네 보안 설정 클래스
+                        JwtAuthenticationFilter.class // 그리고 문제의 필터
+                })
+        }
+)@AutoConfigureMockMvc(addFilters = false)
 public class WatermarkControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
-    private WatermarkService waterMarkService;
+    @MockitoBean private WatermarkService watermarkService;
+    @MockitoBean private UserService userService;
+    @MockitoBean private WebClient webClient;
 
-    @Autowired
-    private ObjectMapper objectMapper;
-/*
     @Test
-    void getAllWatermarks_ShouldReturnList() throws Exception {
-        // given
-        Long userId = 1L;
-        WatermarkDTO dto1 = new WatermarkDTO(1L, "original1.jpg", "watermarked1.jpg", LocalDateTime.parse("2024-01-01T00:00:00"));
-        WatermarkDTO dto2 = new WatermarkDTO(2L, "original2.jpg", "watermarked2.jpg", LocalDateTime.parse("2024-01-02T00:00:00"));
+    @DisplayName("POST /api/watermark - 워터마크 삽입 성공")
+    @WithMockCustomUser(userId = 7L, role = "USER")
+    void insertWatermark_success() throws Exception {
+        Long userId = 7L;
 
-        // Mockito.when(waterMarkService.getAllResult(userId)).thenReturn(List.of(dto1, dto2));
+        InsertResultDTO dto = InsertResultDTO.builder()
+                .artifactId("artifact-123")
+                .fileName("watermarked.png")
+                .s3WatermarkedKey("https://s3.example/watermarks/watermarked.png")
+                .message("abcd")
+                .sha256("sha")
+                .normalizedSha256("nsha")
+                .phash(123L)
+                .createdAt(LocalDateTime.now())
+                .taskId("task-1")
+                .build();
 
-        // when & then
-        mockMvc.perform(get("/watermark")
-                        .param("userId", String.valueOf(userId)))
+        when(watermarkService.insert(eq(userId), any(), eq("abcd"), eq("task-1")))
+                .thenReturn(dto);
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "input.png", "image/png", "pngbytes".getBytes()
+        );
+
+        MockMultipartFile message = new MockMultipartFile(
+                "message", "", "text/plain", "abcd".getBytes(StandardCharsets.UTF_8)
+        );
+
+        mockMvc.perform(multipart("/api/watermark")
+                        .file(file)
+                        .file(message)
+                        .param("taskId", "task-1"))
                 .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                // ResponseDTO 기본 필드 체크
                 .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("워터마크 삽입 성공"))
+                // data 필드 체크
+                .andExpect(jsonPath("$.data.artifactId").value("artifact-123"))
+                .andExpect(jsonPath("$.data.fileName").value("watermarked.png"))
+                .andExpect(jsonPath("$.data.s3WatermarkedKey").value("https://s3.example/watermarks/watermarked.png"))
+                .andExpect(jsonPath("$.data.message").value("abcd"))
+                .andExpect(jsonPath("$.data.taskId").value("task-1"));
+    }
+
+    @Test
+    @DisplayName("GET /api/watermark - 전체 조회 성공 (페이징)")
+    @WithMockCustomUser(userId = 7L, role = "USER")
+    void getAllWatermarks_success() throws Exception {
+        Long userId = 7L;
+
+        InsertResultDTO dto1 = InsertResultDTO.builder()
+                .artifactId("a1").fileName("w1.png").message("m1").build();
+        InsertResultDTO dto2 = InsertResultDTO.builder()
+                .artifactId("a2").fileName("w2.png").message("m2").build();
+
+        when(watermarkService.getAllResult(eq(userId), any()))
+                .thenReturn(new PageImpl<>(List.of(dto1, dto2), PageRequest.of(0, 15), 2));
+
+        mockMvc.perform(get("/api/watermark")
+                        .param("page", "0")
+                        .param("size", "15"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("워터마크 삽입 기록 전체 조회 성공"))
-                .andExpect(jsonPath("$.data", hasSize(2)))
-                .andExpect(jsonPath("$.data[0].originalFilePath").value("original1.jpg"));
+                // PageImpl가 Jackson으로 직렬화되면 content 배열로 들어감
+                .andExpect(jsonPath("$.data.content[0].artifactId").value("a1"))
+                .andExpect(jsonPath("$.data.content[1].artifactId").value("a2"))
+                .andExpect(jsonPath("$.data.totalElements").value(2));
     }
 
     @Test
-    void getWatermark_ShouldReturnOne() throws Exception {
-        // given
-        Long userId = 1L;
-        Long id = 42L;
-        WatermarkDTO dto = new WatermarkDTO(id, "original.jpg", "watermarked.jpg", LocalDateTime.parse("2024-01-01T00:00:00"));
+    @DisplayName("GET /api/watermark/{id} - 단건 조회 성공")
+    @WithMockCustomUser(userId = 7L, role = "USER")
+    void getWatermark_success() throws Exception {
+        Long userId = 7L;
+        Long id = 5L;
 
-        // Mockito.when(waterMarkService.getSingleResult(userId, id)).thenReturn(dto);
+        InsertResultDTO dto = InsertResultDTO.builder()
+                .artifactId("ax")
+                .fileName("one.png")
+                .message("hi")
+                .build();
 
-        // when & then
-        mockMvc.perform(get("/watermark/{id}", id)
-                        .param("userId", String.valueOf(userId)))
+        when(watermarkService.getSingleResult(userId, id)).thenReturn(dto);
+
+        mockMvc.perform(get("/api/watermark/{id}", id))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("워터마크 삽입 기록 조회 성공"))
-                .andExpect(jsonPath("$.data.originalFilePath").value("original.jpg"));
+                .andExpect(jsonPath("$.data.artifactId").value("ax"))
+                .andExpect(jsonPath("$.data.fileName").value("one.png"));
     }
-*/
-    @Test
-    void deleteWatermark_ShouldSucceed() throws Exception {
-        // given
-        Long userId = 1L;
-        Long id = 10L;
 
-        // when & then
-        mockMvc.perform(delete("/watermark/{id}", id)
-                        .param("userId", String.valueOf(userId)))
+    @Test
+    @DisplayName("DELETE /api/watermark/{id} - 삭제 성공")
+    @WithMockCustomUser(userId = 7L, role = "USER")
+    void deleteWatermark_success() throws Exception {
+        Long userId = 7L;
+        Long id = 77L;
+
+        doNothing().when(watermarkService).deleteWatermark(userId, id);
+
+        mockMvc.perform(delete("/api/watermark/{id}", id))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("워터마크 삽입 기록 삭제 성공"))
                 .andExpect(jsonPath("$.data").doesNotExist());
-
-        Mockito.verify(waterMarkService).deleteWatermark(userId, id);
     }
 }

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/service/WatermarkServiceTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/service/WatermarkServiceTest.java
@@ -1,93 +1,265 @@
 package com.deeptruth.deeptruth.service;
 
-import com.deeptruth.deeptruth.base.dto.watermark.WatermarkDTO;
+import com.deeptruth.deeptruth.base.dto.watermark.InsertResultDTO;
+import com.deeptruth.deeptruth.base.dto.watermark.WatermarkFlaskResponseDTO;
+import com.deeptruth.deeptruth.base.exception.ExternalServiceException;
+import com.deeptruth.deeptruth.base.exception.ImageDecodingException;
+import com.deeptruth.deeptruth.base.exception.UserNotFoundException;
 import com.deeptruth.deeptruth.entity.User;
 import com.deeptruth.deeptruth.entity.Watermark;
 import com.deeptruth.deeptruth.repository.UserRepository;
 import com.deeptruth.deeptruth.repository.WatermarkRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 public class WatermarkServiceTest {
-    @Mock
-    private WatermarkRepository watermarkRepository;
+    @Mock private WatermarkRepository watermarkRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private AmazonS3Service amazonS3Service;
+    @Mock private WebClient webClient;
 
-    @Mock
-    private UserRepository userRepository;
-
-    @Mock
-    private AmazonS3Service amazonS3Service;
+    // WebClient fluent 체인 목들
+    @Mock private WebClient.RequestBodyUriSpec uriSpec;
+    @Mock private WebClient.RequestBodySpec bodySpec;
+    @Mock private WebClient.RequestHeadersSpec<?> headersSpec;
+    @Mock private WebClient.ResponseSpec responseSpec;
 
     @InjectMocks
     private WatermarkService watermarkService;
 
     @BeforeEach
-    void setup() {
-        MockitoAnnotations.openMocks(this);
-    }
-/*
-    @Test
-    void getAllResult_ShouldReturnDTOList() {
-        // given
-        Long userId = 1L;
-        User user = new User();
-//        List<Watermark> marks = List.of(
-//                Watermark.builder().user(user).originalFilePath("a.jpg").watermarkedFilePath("b.jpg").build()
-//        );
-
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-       // when(watermarkRepository.findAllByUser(user)).thenReturn(marks);
-
-        // when
-        // List<WatermarkDTO> result = watermarkService.getAllResult(userId);
-
-        // then
-        // assertThat(result).hasSize(1);
-        // assertThat(result.get(0).getOriginalFilePath()).isEqualTo("a.jpg");
+    void setUp() {
+        try {
+            var f = WatermarkService.class.getDeclaredField("flaskServerUrl");
+            f.setAccessible(true);
+            f.set(watermarkService, "http://fake-flask.local");
+        } catch (Exception ignored) {}
     }
 
-    @Test
-    void getSingleResult_ShouldReturnDTO() {
-        // given
-        Long userId = 1L;
-        Long markId = 2L;
-        User user = new User();
-        //Watermark mark = Watermark.builder().originalFilePath("a.jpg").watermarkedFilePath("b.jpg").build();
-
-//        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-//        when(watermarkRepository.findByWatermarkIdAndUser(markId, user)).thenReturn(Optional.of(mark));
-//
-//        // when
-//        WatermarkDTO result = watermarkService.getSingleResult(userId, markId);
-
-        // then
-        //assertThat(result.getOriginalFilePath()).isEqualTo("a.jpg");
+    private void mockWebClientReturning(WatermarkFlaskResponseDTO dto) {
+        when(webClient.post()).thenReturn(uriSpec);
+        when(uriSpec.uri(anyString())).thenReturn(bodySpec);
+        when(bodySpec.contentType(eq(MediaType.MULTIPART_FORM_DATA))).thenReturn(bodySpec);
+        when(bodySpec.body(any(BodyInserters.MultipartInserter.class))).thenReturn((WebClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(eq(WatermarkFlaskResponseDTO.class))).thenReturn(Mono.justOrEmpty(dto));
     }
 
+
     @Test
-    void deleteWatermark_ShouldInvokeRepositoryDelete() {
+    @DisplayName("insert 성공: Flask 응답을 받아 S3 업로드 후 DB 저장 및 DTO 반환")
+    void insert_success() throws Exception {
         // given
-        Long userId = 1L;
-        Long markId = 2L;
-        User user = new User();
+        long userId = 10L;
+        var user = User.builder()
+                .userId(userId)
+                .email("u@test.com")
+                .loginId("login")
+                .name("name")
+                .nickname("nick")
+                .password("pwd")
+                .createdAt(LocalDateTime.now().toLocalDate())
+                .build();
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
+        // Flask가 base64 이미지 반환
+        BufferedImage img = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
+        img.setRGB(0, 0, 0x00FF00); // 임의의 색 한 픽셀
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(img, "png", baos);
+        byte[] tinyPng = baos.toByteArray();
+
+        var flaskDto = new WatermarkFlaskResponseDTO();
+        flaskDto.setImage_base64(java.util.Base64.getEncoder().encodeToString(tinyPng));
+        flaskDto.setFilename("watermarked.png");
+        mockWebClientReturning(flaskDto);
+
+        when(amazonS3Service.uploadStream(
+                any(InputStream.class),
+                argThat(k -> k != null && k.endsWith("watermarked.png")),
+                eq("image/png")
+        )).thenReturn("https://s3.example/watermarks/watermarked.png");
+
+        when(amazonS3Service.uploadStream(
+                any(InputStream.class),
+                argThat(k -> k != null && k.endsWith("message.txt")),
+                eq("text/plain")
+        )).thenReturn("https://s3.example/watermarks/message.txt");
+
+        // DB save mock
+        when(watermarkRepository.save(any(Watermark.class)))
+                .thenAnswer(inv -> inv.getArgument(0, Watermark.class));
+
+        var file = new org.springframework.mock.web.MockMultipartFile(
+                "file", "input.png", "image/png", tinyPng
+        );
+
         // when
-        watermarkService.deleteWatermark(userId, markId);
+        InsertResultDTO result = watermarkService.insert(userId, file, "abcd", "task-1");
 
         // then
-        verify(watermarkRepository).deleteByWatermarkIdAndUser(markId, user);
+        assertThat(result).isNotNull();
+        assertThat(result.getFileName()).isEqualTo("watermarked.png");
+        assertThat(result.getS3WatermarkedKey()).isEqualTo("https://s3.example/watermarks/watermarked.png");
+        assertThat(result.getMessage()).isEqualTo("abcd");
+        assertThat(result.getTaskId()).isEqualTo("task-1");
+
+        verify(userRepository).findById(userId);
+        verify(webClient).post();
+        verify(watermarkRepository).save(any(Watermark.class));
+        verify(amazonS3Service, times(2)).uploadStream(any(InputStream.class), anyString(), anyString());
     }
-*/
+
+    @Test
+    @DisplayName("insert 실패: 유저 없음 -> UserNotFoundException")
+    void insert_userNotFound() {
+        // given
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+        var file = new MockMultipartFile("file", "f.png", "image/png", new byte[]{1,2});
+
+        // when & then
+        assertThatThrownBy(() -> watermarkService.insert(999L, file, "ab", "tid"))
+                .isInstanceOf(UserNotFoundException.class);
+        verifyNoInteractions(webClient);
+        verifyNoInteractions(amazonS3Service);
+        verify(watermarkRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("insert 실패: 메세지 5자 이상 -> IllegalArgumentException")
+    void insert_messageTooLong() {
+        var file = new MockMultipartFile("file", "f.png", "image/png", new byte[]{1,2});
+        assertThatThrownBy(() -> watermarkService.insert(1L, file, "12345", "tid"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("최대 4자");
+    }
+
+
+    @Test
+    void insert_flaskNull() throws Exception {
+        // given
+        Long userId = 1L;
+        when(userRepository.findById(userId))
+                .thenReturn(Optional.of(User.builder().userId(userId).build()));
+
+        // 유효한 PNG 바이트 생성
+        BufferedImage img = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(img, "png", baos);
+        byte[] validPng = baos.toByteArray();
+        mockWebClientReturning(null);
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "input.png", "image/png", validPng);
+
+        // 실행 & 검증
+        assertThatThrownBy(() -> watermarkService.insert(userId, file, "abcd", "task-1"))
+                .isInstanceOf(ExternalServiceException.class)
+                .hasMessageContaining("비어"); // "Flask 서버 응답이 비어 있습니다."
+    }
+
+    @Test
+    @DisplayName("insert 실패: Flask base64 디코딩 실패 -> ImageDecodingException")
+    void insert_invalidBase64() throws Exception {
+        // given
+        long userId = 1L;
+        when(userRepository.findById(userId))
+                .thenReturn(Optional.of(User.builder().userId(userId).email("a@a.com").loginId("a").name("n").nickname("n").password("p").build()));
+
+        BufferedImage img = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(img, "png", baos);
+        byte[] validPng = baos.toByteArray();
+
+        MockMultipartFile file =
+                new MockMultipartFile("file", "input.png", "image/png", validPng);
+
+        // Flask가 "깨진 base64" 반환하도록 목킹
+        WatermarkFlaskResponseDTO flaskDto = new WatermarkFlaskResponseDTO();
+        flaskDto.setFilename("watermarked.png");
+        flaskDto.setImage_base64("!!not-base64!!"); // 디코딩 실패 유도
+        mockWebClientReturning(flaskDto);
+        assertThatThrownBy(() -> watermarkService.insert(userId, file, "ab", "tid"))
+                .isInstanceOf(ImageDecodingException.class);
+    }
+
+    @Test
+    @DisplayName("getAllResult 성공: 페이지 결과 반환")
+    void getAllResult_success() {
+        long userId = 7L;
+        when(userRepository.findById(userId)).thenReturn(Optional.of(User.builder().userId(userId).build()));
+
+        var entity = Watermark.builder()
+                .watermarkId(1L)
+                .artifactId("art")
+                .fileName("f.png")
+                .message("ab")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        Page<Watermark> page = new PageImpl<>(List.of(entity), PageRequest.of(0, 10), 1);
+        when(watermarkRepository.findByUser_UserId(eq(userId), any(Pageable.class)))
+                .thenReturn(page);
+
+        var result = watermarkService.getAllResult(userId, PageRequest.of(0, 10));
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getArtifactId()).isEqualTo("art");
+    }
+
+    @Test
+    @DisplayName("getSingleResult 실패: 해당 사용자에 결과 없음 -> WatermarkNotFoundException")
+    void getSingleResult_notFound() {
+        long userId = 5L;
+        when(userRepository.findById(userId)).thenReturn(Optional.of(User.builder().userId(userId).build()));
+        when(watermarkRepository.findByWatermarkIdAndUser(eq(999L), any(User.class)))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> watermarkService.getSingleResult(userId, 999L))
+                .hasMessageContaining("not found");
+    }
+
+
+    @Test
+    @DisplayName("deleteWatermark 실패: 삭제수 0 -> WatermarkNotFoundException")
+    void deleteWatermark_notFound() {
+        long userId = 3L;
+        when(userRepository.findById(userId)).thenReturn(Optional.of(User.builder().userId(userId).build()));
+        when(watermarkRepository.deleteByWatermarkIdAndUser(eq(100L), any(User.class))).thenReturn(0);
+
+        assertThatThrownBy(() -> watermarkService.deleteWatermark(userId, 100L))
+                .hasMessageContaining("not found");
+    }
+
 }

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/testsecurity/WithMockCustomUser.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/testsecurity/WithMockCustomUser.java
@@ -1,0 +1,17 @@
+package com.deeptruth.deeptruth.testsecurity;
+
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+import java.lang.annotation.*;
+
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+    long userId() default 1L;
+    String loginId() default "testLogin";
+    String email() default "test@example.com";
+    String nickname() default "tester";
+    String name() default "테스트유저";
+    String role() default "USER";
+}

--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/testsecurity/WithMockCustomUserSecurityContextFactory.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/testsecurity/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,39 @@
+package com.deeptruth.deeptruth.testsecurity;
+
+import com.deeptruth.deeptruth.config.CustomUserDetails;
+import com.deeptruth.deeptruth.entity.User;
+import com.deeptruth.deeptruth.base.Enum.Role;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.List;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+        User user = User.builder()
+                .userId(annotation.userId())
+                .loginId(annotation.loginId())
+                .email(annotation.email())
+                .nickname(annotation.nickname())
+                .name(annotation.name())
+                .password("N/A")
+                .role(Role.valueOf(annotation.role()))
+                .build();
+
+        CustomUserDetails principal = new CustomUserDetails(user);
+
+        var auth = new UsernamePasswordAuthenticationToken(
+                principal,
+                "N/A",
+                List.of(new SimpleGrantedAuthority("ROLE_" + annotation.role()))
+        );
+        SecurityContext ctx = SecurityContextHolder.createEmptyContext();
+        ctx.setAuthentication(auth);
+        return ctx;
+    }
+}


### PR DESCRIPTION
## 📝 Summary
- Watermark 서비스 및 컨트롤러 단위 테스트 작성
- 인증된 사용자 시나리오 테스트를 위한 @WithMockCustomUser 어노테이션 추가

## 💻 Describe your changes
### 1. Service Test (WatermarkServiceTest)
- Flask WebClient 응답 mock 처리
- AmazonS3Service mock 업로드 검증
- UserNotFoundException, ImageDecodingException 등 예외 상황 검증
- DB 저장 및 DTO 반환 로직 테스트

### 2. Controller Test (WatermarkControllerTest)
- MockMvc 기반 워터마크 삽입 API 성공/실패 케이스 검증
- multipart 업로드 + 파라미터 전달 시나리오 테스트
- ResponseDTO 기본 필드(status, success, message, data) 검증

### 3. WithMockCustomUser 어노테이션
- @WithSecurityContext 기반으로 SecurityContext에 CustomUserDetails 주입
- 컨트롤러 테스트에서 인증 유저 시나리오를 간단히 표현 가능


## #️⃣ Issue number and link
#44 #45 

## 💬 Message to the Reviewer
