### PR TITLE
Test: Deepfake 서비스/컨트롤러 테스트 추가

### DIFF
--- a/deeptruth/src/test/java/com/deeptruth/deeptruth/service/DeepfakeDetectionServiceTest.java
+++ b/deeptruth/src/test/java/com/deeptruth/deeptruth/service/DeepfakeDetectionServiceTest.java
@@ -1,7 +1,10 @@
 package com.deeptruth.deeptruth.service;
 
+import com.deeptruth.deeptruth.base.Enum.DeepfakeDetector;
+import com.deeptruth.deeptruth.base.Enum.DeepfakeMode;
 import com.deeptruth.deeptruth.base.Enum.DeepfakeResult;
-import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionDTO;
+import com.deeptruth.deeptruth.base.dto.deepfake.*;
+import com.deeptruth.deeptruth.base.exception.*;
 import com.deeptruth.deeptruth.entity.DeepfakeDetection;
 import com.deeptruth.deeptruth.entity.User;
 import com.deeptruth.deeptruth.repository.DeepfakeDetectionRepository;
@@ -9,122 +12,516 @@ import com.deeptruth.deeptruth.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
-import static org.mockito.BDDMockito.then;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 
 import java.io.IOException;
-import java.time.LocalDateTime;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.given;
+import java.io.InputStream;
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class DeepfakeDetectionServiceTest {
 
-    @InjectMocks
-    private DeepfakeDetectionService deepfakeDetectionService;
+    @InjectMocks private DeepfakeDetectionService service;
 
-    @Mock
-    private UserRepository userRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private DeepfakeDetectionRepository deepfakeDetectionRepository;
+    @Mock private AmazonS3Service amazonS3Service;
+    @Mock private DeepfakeViewAssembler assembler;
+    @Mock private WebClient webClient;
 
-    @Mock
-    private DeepfakeDetectionRepository deepfakeDetectionRepository;
-
-    @Mock
-    private AmazonS3Service amazonS3Service;
-
-    private User mockUser;
-    private DeepfakeDetection detection1;
-    private DeepfakeDetection detection2;
+    @Mock private WebClient.RequestBodyUriSpec uriSpec;
+    @Mock private WebClient.RequestBodySpec bodySpec;
+    @Mock private WebClient.RequestHeadersSpec<?> headersSpec;
+    @Mock private WebClient.ResponseSpec responseSpec;
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
-
-        mockUser = User.builder()
-                .userId(1L)
-                .email("test@example.com")
-                .build();
-
-        detection1 = DeepfakeDetection.builder()
-                .deepfakeDetectionId(1L)
-                .user(mockUser)
-                .filePath("path1.mp4")
-                .result(DeepfakeResult.FAKE)
-                .createdAt(LocalDateTime.now())
-                .build();
-
-        detection2 = DeepfakeDetection.builder()
-                .deepfakeDetectionId(2L)
-                .user(mockUser)
-                .filePath("path2.mp4")
-                .result(DeepfakeResult.REAL)
-                .createdAt(LocalDateTime.now())
-                .build();
-    }
-/*
-    @Test
-    @DisplayName("영상을 업로드하고 deepfake 반환값을 받는다. ")
-    void uploadVideo_ShouldReturnS3Url() throws IOException {
-        // given
-        Long userId = 1L;
-        MultipartFile multipartFile = new MockMultipartFile("file", "video.mp4", "video/mp4", "video content".getBytes());
-        String uploadedUrl = "https://s3.amazonaws.com/deepfake/video.mp4";
-
-        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
-        given(amazonS3Service.uploadFile(anyString(), any(MultipartFile.class))).willReturn(uploadedUrl);
-
-        // when
-        DeepfakeDetectionDTO result = deepfakeDetectionService.uploadVideo(userId, multipartFile);
-
-        // then
-        assertNotNull(result);
-        assertEquals(uploadedUrl, result.getFilePath());
-        assertEquals(DeepfakeResult.FAKE, result.getResult()); // 하드코딩 값 기준
-
-        then(userRepository).should().findById(userId);
-        then(amazonS3Service).should().uploadFile("deepfake", multipartFile);
-        verify(deepfakeDetectionRepository, times(1)).save(any(DeepfakeDetection.class));
+        try {
+            var f = WatermarkService.class.getDeclaredField("flaskServerUrl");
+            f.setAccessible(true);
+            f.set(service, "http://fake-flask.local");
+        } catch (Exception ignored) {}
     }
 
+
+    private void mockWebClientReturning(FlaskResponseDTO dto) {
+        when(webClient.post()).thenReturn(uriSpec);
+        when(uriSpec.uri(anyString())).thenReturn(bodySpec);
+        when(bodySpec.contentType(eq(MediaType.MULTIPART_FORM_DATA))).thenReturn(bodySpec);
+        when(bodySpec.body(any(BodyInserters.MultipartInserter.class))).thenReturn((WebClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(eq(FlaskResponseDTO.class))).thenReturn(Mono.justOrEmpty(dto));
+    }
+
+    private static MockMultipartFile mockFile(String name, String contentType, byte[] bytes) {
+        return new MockMultipartFile("file", name, contentType, bytes);
+    }
+
+    private static User user(long id) {
+        return User.builder()
+                .userId(id)
+                .email("u@test.com")
+                .loginId("login")
+                .name("name")
+                .nickname("nick")
+                .password("pwd")
+                .createdAt(LocalDate.now())
+                .build();
+    }
+
+    private static FlaskResponseDTO minimalFlaskResponse() {
+        FlaskResponseDTO r = new FlaskResponseDTO();
+        r.setTaskId("tid-123");
+        r.setImageUrl("s3://after-upload.jpg");
+        r.setResult(DeepfakeResult.FAKE); // or REAL
+        r.setScoreWeighted(0.77f);
+        r.setThresholdTau(0.5f);
+        r.setFrameVoteRatio(0.9f);
+        r.setAverageConfidence(0.8f);
+        r.setMedianConfidence(0.81f);
+        r.setMaxConfidence(0.95f);
+        r.setVarianceConfidence(0.02f);
+        r.setFramesProcessed(123);
+        r.setProcessingTimeSec(1.23f);
+        r.setMode(DeepfakeMode.DEFAULT.name());
+        r.setDetector(DeepfakeDetector.DLIB.name());
+        r.setUseTta(true);
+        r.setUseIllum(false);
+        r.setMinFace(64);
+        r.setSampleCount(8);
+        r.setSmoothWindow(3);
+
+        Speed sp = new Speed();
+        sp.setMsPerSample(12.3f);
+        sp.setTargetFps(20.0f);
+        sp.setMaxLatencyMs(200.0f);
+        sp.setSpeedOk(true);
+        sp.setFpsProcessed(18.7f);
+        r.setSpeed(sp);
+
+        StabilityEvidence se = new StabilityEvidence();
+        se.setTemporalDeltaMean(0.1f);
+        se.setTemporalDeltaStd(0.02f);
+        se.setTtaMean(0.3f);
+        se.setTtaStd(0.05f);
+        r.setStabilityEvidence(se);
+
+        Timeseries ts = new Timeseries();
+        ts.setPerFrameConf(Arrays.asList(0.1f, 0.5f, 0.9f));
+        ts.setVmin(0.0f);
+        ts.setVmax(1.0f);
+        r.setTimeseries(ts);
+
+        return r;
+    }
+
     @Test
-    @DisplayName("특정 탐지 결과를 반환한다")
+    @DisplayName("createDetection 성공: Flask 응답 매핑, base64 업로드, bullet 계산, 저장까지")
+    void createDetection_success() throws IOException {
+        long uid = 10L;
+        when(userRepository.findById(uid)).thenReturn(Optional.of(user(uid)));
+
+        // 파일
+        byte[] bytes = new byte[]{1, 2, 3};
+        MockMultipartFile file = mockFile("video.mp4", "video/mp4", bytes);
+
+        FlaskResponseDTO flask = minimalFlaskResponse();
+        flask.setBase64Url(Base64.getEncoder().encodeToString(new byte[]{9, 9, 9}));
+        flask.setImageUrl(null);
+        mockWebClientReturning(flask);
+
+        // S3 업로드 (base64 이미지)
+        when(amazonS3Service.uploadBase64Image(any(InputStream.class), argThat(k -> k.startsWith("deepfake/" + uid + "/"))))
+                .thenReturn("https://s3.example/df/" + uid + "/thumb.jpg");
+
+        when(deepfakeDetectionRepository.save(any(DeepfakeDetection.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        // bullets
+        List<BulletDTO> stability = List.of(
+                BulletDTO.builder()
+                        .key("a")
+                        .label("b")
+                        .value(0.7f)
+                        .bands(null)
+                        .direction("higher")
+                        .unit(null)
+                        .build()
+        );
+
+        List<BulletDTO> speed = List.of(
+                BulletDTO.builder()
+                        .key("c")
+                        .label("d")
+                        .value(0.8f)
+                        .bands(null)
+                        .direction("higher")
+                        .unit(null)
+                        .build()
+        );
+
+        when(assembler.makeStabilityBullets(any())).thenReturn(stability);
+        when(assembler.makeSpeedBullets(any())).thenReturn(speed);
+
+        Map<String, String> form = new HashMap<>();
+        form.put("mode", "DEFAULT");
+        form.put("detector", "DLIB");
+        form.put("taskId", "tid-123");
+        form.put("use_tta", "true");
+
+        DeepfakeDetectionDTO dto = service.createDetection(uid, file, form);
+
+        assertThat(dto).isNotNull();
+        assertThat(dto.getTaskId()).isEqualTo("tid-123");
+        assertThat(dto.getResult()).isEqualTo(DeepfakeResult.FAKE);
+        assertThat(dto.getFilePath()).isEqualTo("https://s3.example/df/" + uid + "/thumb.jpg");
+
+        verify(webClient).post();
+        verify(amazonS3Service).uploadBase64Image(any(InputStream.class), anyString());
+        verify(deepfakeDetectionRepository).save(any(DeepfakeDetection.class));
+        verify(assembler).makeStabilityBullets(any());
+        verify(assembler).makeSpeedBullets(any());
+    }
+
+    @Test
+    @DisplayName("createDetection 실패: 사용자 없음")
+    void createDetection_userNotFound() {
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+        MockMultipartFile file = mockFile("x.png", "image/png", new byte[]{1});
+
+        assertThatThrownBy(() -> service.createDetection(999L, file, Map.of()))
+                .isInstanceOf(UserNotFoundException.class);
+
+        verifyNoInteractions(webClient, amazonS3Service, deepfakeDetectionRepository, assembler);
+    }
+
+    @Test
+    @DisplayName("createDetection 실패: 파일 비었음")
+    void createDetection_fileEmpty() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+        MockMultipartFile file = mockFile("x.png", "image/png", new byte[0]);
+        assertThatThrownBy(() -> service.createDetection(1L, file, Map.of()))
+                .isInstanceOf(FileEmptyException.class);
+    }
+
+
+    @Test
+    @DisplayName("createDetection 실패: 지원하지 않는 미디어 타입")
+    void createDetection_unsupportedMediaType() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+        MockMultipartFile file = mockFile("x.bin", "application/pdf", new byte[]{1});
+        assertThatThrownBy(() -> service.createDetection(1L, file, Map.of()))
+                .isInstanceOf(UnsupportedMediaTypeException.class);
+    }
+
+    @Test
+    @DisplayName("createDetection 실패: Flask 응답 null")
+    void createDetection_flaskNull() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+        MockMultipartFile file = mockFile("x.png", "image/png", new byte[]{1});
+
+        mockWebClientReturning(null);
+
+        assertThatThrownBy(() -> service.createDetection(1L, file, Map.of()))
+                .isInstanceOf(ExternalServiceException.class)
+                .hasMessageContaining("null");
+    }
+
+    @Test
+    @DisplayName("createDetection 실패: Flask HTTP 에러(4xx/5xx)")
+    void createDetection_flaskHttpError() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+        MockMultipartFile file = mockFile("x.png", "image/png", new byte[]{1});
+
+        when(webClient.post()).thenReturn(uriSpec);
+        when(uriSpec.uri(anyString())).thenReturn(bodySpec);
+        when(bodySpec.contentType(any())).thenReturn(bodySpec);
+        when(bodySpec.body(any(BodyInserters.MultipartInserter.class))).thenReturn((WebClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(FlaskResponseDTO.class))
+                .thenThrow(new org.springframework.web.reactive.function.client.WebClientResponseException(
+                        "boom", 500, "Internal", null, null, null));
+
+        assertThatThrownBy(() -> service.createDetection(1L, file, Map.of()))
+                .isInstanceOf(ExternalServiceException.class)
+                .hasMessageContaining("Flask HTTP error");
+    }
+
+    @Test
+    @DisplayName("createDetection 실패: Flask 요청 실패(연결/타임아웃)")
+    void createDetection_flaskRequestError() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+        MockMultipartFile file = mockFile("x.png", "image/png", new byte[]{1});
+
+        when(webClient.post()).thenReturn(uriSpec);
+        when(uriSpec.uri(anyString())).thenReturn(bodySpec);
+        when(bodySpec.contentType(any())).thenReturn(bodySpec);
+        when(bodySpec.body(any(BodyInserters.MultipartInserter.class))).thenReturn((WebClient.RequestHeadersSpec) headersSpec);
+        when(headersSpec.retrieve()).thenReturn(responseSpec);
+
+        WebClientRequestException connError = new WebClientRequestException(
+                new IOException("conn fail"),
+                HttpMethod.POST,
+                URI.create("http://fake-flask.local/predict"),
+                HttpHeaders.EMPTY
+        );
+        when(responseSpec.bodyToMono(eq(FlaskResponseDTO.class)))
+                .thenReturn(Mono.error(connError));
+        assertThatThrownBy(() -> service.createDetection(1L, file, Map.of()))
+                .isInstanceOf(ExternalServiceException.class)
+                .hasMessageContaining("request failed");
+    }
+
+    @Test
+    @DisplayName("createDetection 실패: 필수 필드 누락 → DataMappingException")
+    void createDetection_missingRequiredFields() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+        MockMultipartFile file = mockFile("x.png", "image/png", new byte[]{1});
+
+        FlaskResponseDTO bad = new FlaskResponseDTO(); // taskId/imageUrl/result 없음
+        mockWebClientReturning(bad);
+
+        assertThatThrownBy(() -> service.createDetection(1L, file, Map.of()))
+                .isInstanceOf(DataMappingException.class);
+    }
+
+    @Test
+    @DisplayName("createDetection 실패: 잘못된 enum 값 → InvalidEnumValueException")
+    void createDetection_invalidEnum() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+        MockMultipartFile file = mockFile("x.png", "image/png", new byte[]{1});
+
+        FlaskResponseDTO r = minimalFlaskResponse();
+        r.setMode("NOPE"); // 잘못된 모드
+        mockWebClientReturning(r);
+
+        assertThatThrownBy(() -> service.createDetection(1L, file, Map.of()))
+                .isInstanceOf(InvalidEnumValueException.class);
+    }
+
+    @Test
+    @DisplayName("createDetection 실패: bullet assembler 가 null 반환 → DataMappingException")
+    void createDetection_bulletsNull() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+        MockMultipartFile file = mockFile("x.png", "image/png", new byte[]{1});
+
+        FlaskResponseDTO r = minimalFlaskResponse();
+        mockWebClientReturning(r);
+
+        List<BulletDTO> speed = List.of(
+                BulletDTO.builder()
+                        .key("c")
+                        .label("d")
+                        .value(0.8f)
+                        .bands(null)
+                        .direction("higher")
+                        .unit(null)
+                        .build()
+        );
+
+        when(assembler.makeStabilityBullets(any())).thenReturn(null);
+        when(assembler.makeSpeedBullets(any())).thenReturn(speed);
+
+        assertThatThrownBy(() -> service.createDetection(1L, file, Map.of()))
+                .isInstanceOf(DataMappingException.class)
+                .hasMessageContaining("bullet");
+    }
+
+    // ========== getAllResult ==========
+
+    @Test
+    @DisplayName("getAllResult 성공: 페이지 결과 반환")
+    void getAllResult_success() {
+        long uid = 3L;
+        when(userRepository.findById(uid)).thenReturn(Optional.of(user(uid)));
+
+        DeepfakeDetection entity = new DeepfakeDetection();
+        entity.setDeepfakeDetectionId(1L);
+        entity.setTaskId("t1");
+        entity.setResult(DeepfakeResult.REAL);
+        Page<DeepfakeDetection> page = new PageImpl<>(List.of(entity), PageRequest.of(0,10), 1);
+
+        when(deepfakeDetectionRepository.findByUser_UserId(eq(uid), any(Pageable.class)))
+                .thenReturn(page);
+
+        Page<DeepfakeDetectionListDTO> out = service.getAllResult(uid, PageRequest.of(0,10));
+        assertThat(out.getTotalElements()).isEqualTo(1);
+        assertThat(out.getContent().get(0).getTaskId()).isEqualTo("t1");
+    }
+
+    @Test
+    @DisplayName("getAllResult 실패: pageable null")
+    void getAllResult_pageableNull() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+        assertThatThrownBy(() -> service.getAllResult(1L, null))
+                .isInstanceOf(DataMappingException.class)
+                .hasMessageContaining("pageable");
+    }
+
+    // ========== getSingleResult ==========
+
+    @Test
+    @DisplayName("getSingleResult 성공")
     void getSingleResult_success() {
-        Long detectionId = 1L;
-        Long userId = 1L;
+        long uid = 4L;
+        when(userRepository.findById(uid)).thenReturn(Optional.of(user(uid)));
 
-        User mockUser = User.builder().userId(userId).email("test@example.com").build();
-        DeepfakeDetection mockDetection = DeepfakeDetection.builder()
-                .deepfakeDetectionId(detectionId)
-                .user(mockUser)
-                .filePath("test/path.mp4")
-                .result(DeepfakeResult.FAKE)
-                .createdAt(LocalDateTime.now())
-                .build();
+        DeepfakeDetection entity = new DeepfakeDetection();
+        entity.setDeepfakeDetectionId(10L);
+        entity.setTaskId("tid");
+        entity.setResult(DeepfakeResult.REAL);
 
-        Mockito.when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-        Mockito.when(deepfakeDetectionRepository.findByDeepfakeDetectionIdAndUser(detectionId, mockUser)).thenReturn(Optional.of(mockDetection));
+        when(deepfakeDetectionRepository.findByDeepfakeDetectionIdAndUser(eq(10L), any(User.class)))
+                .thenReturn(Optional.of(entity));
 
-        DeepfakeDetectionDTO result = deepfakeDetectionService.getSingleResult(userId, detectionId);
+        List<BulletDTO> stability = List.of(
+                BulletDTO.builder()
+                        .key("a")
+                        .label("b")
+                        .value(0.7f)
+                        .bands(null)
+                        .direction("higher")
+                        .unit(null)          
+                        .build()
+        );
 
-        assertEquals("test/path.mp4", result.getFilePath());
-        assertEquals(DeepfakeResult.FAKE, result.getResult());
+        List<BulletDTO> speed = List.of(
+                BulletDTO.builder()
+                        .key("c")
+                        .label("d")
+                        .value(0.8f)
+                        .bands(null)
+                        .direction("higher")
+                        .unit(null)
+                        .build()
+        );
+
+        when(assembler.makeStabilityBullets(entity))
+                .thenReturn(stability);
+        when(assembler.makeSpeedBullets(entity))
+                .thenReturn(speed);
+
+        DeepfakeDetectionDTO dto = service.getSingleResult(uid, 10L);
+        assertThat(dto.getTaskId()).isEqualTo("tid");
+        assertThat(dto.getResult()).isEqualTo(DeepfakeResult.REAL);
     }
-*/
-    @Test
-    @DisplayName("탐지 결과를 삭제한다")
-    void deleteResult() {
-        when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
-        when(deepfakeDetectionRepository.findByDeepfakeDetectionIdAndUser(1L, mockUser)).thenReturn(Optional.of(detection1));
 
-        assertDoesNotThrow(() -> deepfakeDetectionService.deleteResult(1L, 1L));
-        verify(deepfakeDetectionRepository, times(1)).deleteByDeepfakeDetectionIdAndUser(1L, mockUser);
+    @Test
+    @DisplayName("getSingleResult 실패: 사용자 없음")
+    void getSingleResult_userNotFound() {
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.getSingleResult(1L, 10L))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("getSingleResult 실패: 엔티티 없음")
+    void getSingleResult_notFound() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+        when(deepfakeDetectionRepository.findByDeepfakeDetectionIdAndUser(eq(10L), any(User.class)))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getSingleResult(1L, 10L))
+                .isInstanceOf(DetectionNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("getSingleResult 실패: bullet assembler 가 null 반환 → DataCorruptionException")
+    void getSingleResult_bulletsNull() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+
+        DeepfakeDetection entity = new DeepfakeDetection();
+        when(deepfakeDetectionRepository.findByDeepfakeDetectionIdAndUser(eq(10L), any(User.class)))
+                .thenReturn(Optional.of(entity));
+
+        List<BulletDTO> speed = List.of(
+                BulletDTO.builder()
+                        .key("c")
+                        .label("d")
+                        .value(0.8f)
+                        .bands(null)
+                        .direction("higher")
+                        .unit(null)
+                        .build()
+        );
+
+        when(assembler.makeStabilityBullets(entity)).thenReturn(null);
+        when(assembler.makeSpeedBullets(entity)).thenReturn(speed);
+
+        assertThatThrownBy(() -> service.getSingleResult(1L, 10L))
+                .isInstanceOf(DataCorruptionException.class)
+                .hasMessageContaining("null list");
+    }
+
+    // ========== deleteResult ==========
+
+    @Test
+    @DisplayName("deleteResult 성공")
+    void deleteResult_success() {
+        long uid = 8L;
+        when(userRepository.findById(uid)).thenReturn(Optional.of(user(uid)));
+        DeepfakeDetection entity = new DeepfakeDetection();
+        when(deepfakeDetectionRepository.findByDeepfakeDetectionIdAndUser(eq(100L), any(User.class)))
+                .thenReturn(Optional.of(entity));
+        when(deepfakeDetectionRepository.deleteByDeepfakeDetectionIdAndUser(eq(100L), any(User.class)))
+                .thenReturn(1);
+
+        service.deleteResult(uid, 100L);
+
+        verify(deepfakeDetectionRepository).deleteByDeepfakeDetectionIdAndUser(eq(100L), any(User.class));
+    }
+
+    @Test
+    @DisplayName("deleteResult 실패: 사용자 없음")
+    void deleteResult_userNotFound() {
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.deleteResult(1L, 100L))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("deleteResult 실패: 대상 없음(조회 단계)")
+    void deleteResult_notFoundOnLookup() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+        when(deepfakeDetectionRepository.findByDeepfakeDetectionIdAndUser(eq(100L), any(User.class)))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.deleteResult(1L, 100L))
+                .isInstanceOf(DetectionNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("deleteResult 실패: 삭제 카운트 0")
+    void deleteResult_deletedZero() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+        when(deepfakeDetectionRepository.findByDeepfakeDetectionIdAndUser(eq(100L), any(User.class)))
+                .thenReturn(Optional.of(new DeepfakeDetection()));
+        when(deepfakeDetectionRepository.deleteByDeepfakeDetectionIdAndUser(eq(100L), any(User.class)))
+                .thenReturn(0);
+
+        assertThatThrownBy(() -> service.deleteResult(1L, 100L))
+                .isInstanceOf(DetectionNotFoundException.class);
     }
 }


### PR DESCRIPTION
## 📝 Summary
- 딥페이크 탐지 모듈의 서비스 단위 테스트와 컨트롤러 단위 테스트를 추가했습니다.
- Flask 연동 실패 케이스, DTO 매핑, MockMvc 기반의 API 응답 검증을 포함합니다.

## 💻 Describe your changes
### 1) Service Test (DeepfakeDetectionServiceTest)
- `createDetection_success`: Flask 응답 매핑, base64 업로드, bullet 계산, DB 저장 로직 정상 동작 검증
- `createDetection_flaskRequestError`: Flask 서버 연결/타임아웃 시 ExternalServiceException 발생 검증
- `getSingleResult`, `getAllResult`, `deleteResult` 정상 동작 시나리오 추가

### 2) Controller Test (DeepfakeDetectionControllerTest)
- `POST /api/deepfake`: 멀티파트 업로드 성공 응답 검증 (taskId, result, filePath 등)
- `GET /api/deepfake/{id}`: 단건 조회 성공 응답 검증
- `GET /api/deepfake`: 페이지네이션 전체 조회 성공 응답 검증
- `DELETE /api/deepfake/{id}`: 삭제 성공 응답 검증

### 3) 기타
- `@WithMockCustomUser` 활용하여 인증 객체를 주입, 보안 필터 체인은 `addFilters=false`로 비활성화
-` JwtAuthenticationFilter`를 테스트 스코프에서 제외하여 JwtUtil 빈 의존성 문제 해결

## #️⃣ Issue number and link
#34 #35 

## 💬 Message to the Reviewer
현재는 시큐리티 필터를 제외했는데, 인증/인가를 실제로 검증하는 E2E 테스트도 별도로 구성할지 의견 부탁드립니다.
