### PR TITLE
Fix: pHash 임계값 변경

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkDetectionService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/WatermarkDetectionService.java
@@ -35,8 +35,7 @@ public class WatermarkDetectionService {
     @Value("${flask.watermark-server.url}")
     private String flaskBaseUrl;
 
-    // pHash 임계값(64bit): 실데이터로 튜닝 요망 (10~12 사이 권장)
-    private static final int PHASH_THRESHOLD = 10;
+    private static final int PHASH_THRESHOLD = 30;
 
 
     public DetectResultDTO detect(Long userId, MultipartFile file, String taskId) {


### PR DESCRIPTION
## 📝 Summary
현재 phash 임계값이 18로 설정되어 있어, 이미지를 조금만 크롭하거나 변형해도 유사도가 크게 떨어지는 문제가 있었습니다.  
이를 해결하기 위해 임계값을 30으로 상향 조정했습니다.

## 💻 Describe your changes
- phash 임계값 18 → 30으로 조정
- 여러 크롭/리사이즈 테스트를 통해 안정적인 결과 확인
- 
## #️⃣ Issue number and link
#44 

## 💬 Message to the Reviewer
