### PR TITLE
Feat: WebSocket STOMP 인증용 WebSocketAuthChannelInterceptor 추가

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebSocketAuthChannelInterceptor.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebSocketAuthChannelInterceptor.java
@@ -1,0 +1,44 @@
+package com.deeptruth.deeptruth.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor acc = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (acc == null) return message;
+
+        if (StompCommand.CONNECT.equals(acc.getCommand())) {
+            // 프론트에서 connectHeaders: { loginId: "..." } 로 보낸 값 읽기
+            String loginId = acc.getFirstNativeHeader("loginId");
+            if (loginId != null && !loginId.isBlank()) {
+                acc.setUser(new UsernamePasswordAuthenticationToken(loginId, null, List.of()));
+                log.info("[WS-AUTH] CONNECT as {}", loginId);
+            } else {
+                log.warn("[WS-AUTH] CONNECT without loginId header");
+            }
+        }
+
+        if (StompCommand.SUBSCRIBE.equals(acc.getCommand())) {
+            log.info("[WS] SUBSCRIBE dest={}, principal={}",
+                    acc.getDestination(),
+                    acc.getUser() != null ? acc.getUser().getName() : "null");
+        }
+
+        return message;
+    }
+}
+

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebSocketConfig.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebSocketConfig.java
@@ -13,12 +13,15 @@ import org.springframework.web.socket.server.support.HttpSessionHandshakeInterce
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Value("${app.frontend.url}")
     private String frontendUrl;
 
     @Value("${app.backend.url}")
     private String backendUrl;
+
+    private final WebSocketAuthChannelInterceptor authInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -33,6 +36,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .setAllowedOrigins(frontendUrl, backendUrl)
                 .addInterceptors(httpSessionHandshakeInterceptor())
                 .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(authInterceptor);
     }
 
     @Bean


### PR DESCRIPTION
## 📝 Summary
- WebSocket(STOMP) 연결 시점(`CONNECT` 단계)에 사용자 인증 정보를 추출하고 `Principal` 객체를 세션에 등록하는 `WebSocketAuthChannelInterceptor`를 추가합니다.
- 이를 통해 `convertAndSendToUser(loginId, "/topic/…", payload)` 형태의 유저별 메시지 전송이 정상적으로 작동하도록 개선했습니다

## 💻 Describe your changes
### 1️⃣ `WebSocketAuthChannelInterceptor` 추가

* 클라이언트가 STOMP `CONNECT` 요청 시 전송한 헤더(`loginId` 혹은 `Authorization`)를 읽어 `Principal`로 등록
* 등록된 `Principal`은 WebSocket 세션 전체에서 유지되어 이후 `convertAndSendToUser()` 호출 시 자동 매칭됩니다.

```java
@Slf4j
@Component
@RequiredArgsConstructor
public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {

    @Override
    public Message<?> preSend(Message<?> message, MessageChannel channel) {
        StompHeaderAccessor acc = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
        if (acc == null) return message;

        if (StompCommand.CONNECT.equals(acc.getCommand())) {
            // 간단한 버전: 헤더에서 loginId 추출
            String loginId = acc.getFirstNativeHeader("loginId");

            if (loginId != null && !loginId.isBlank()) {
                acc.setUser(new UsernamePasswordAuthenticationToken(loginId, null, List.of()));
                log.info("[WS-AUTH] CONNECT as {}", loginId);
            } else {
                log.warn("[WS-AUTH] CONNECT without loginId header");
            }
        }
        return message;
    }
}
```

---

### 2️⃣ `WebSocketConfig`에 인터셉터 등록

* 기존의 STOMP 설정 클래스에 `ChannelInterceptor`를 주입하고 등록했습니다.
* `@RequiredArgsConstructor` 사용으로 생성자 주입 방식 적용

```java
@Configuration
@EnableWebSocketMessageBroker
@RequiredArgsConstructor
public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {

    @Value("${app.frontend.url}")
    private String frontendUrl;

    @Value("${app.backend.url}")
    private String backendUrl;

    private final WebSocketAuthChannelInterceptor wsAuth;

    @Override
    public void configureClientInboundChannel(ChannelRegistration registration) {
        registration.interceptors(wsAuth); // 🔑 인터셉터 등록
    }

    @Override
    public void registerStompEndpoints(StompEndpointRegistry registry) {
        registry.addEndpoint("/ws")
                .setAllowedOriginPatterns(frontendUrl, backendUrl)
                .withSockJS();
    }

    @Override
    public void configureMessageBroker(MessageBrokerRegistry config) {
        config.setApplicationDestinationPrefixes("/app");
        config.setUserDestinationPrefix("/user");
        config.enableSimpleBroker("/topic", "/queue");
    }
}
```

## #️⃣ Issue number and link

## 💬 Message to the Reviewer
